### PR TITLE
[Feat] GPT API + RAG 기반 코스 추천, 코스 상세 / 코스 옵션 / 랜덤 코스 조회 구현

### DIFF
--- a/src/main/java/com/example/ondongnae/backend/course/controller/CourseController.java
+++ b/src/main/java/com/example/ondongnae/backend/course/controller/CourseController.java
@@ -1,9 +1,6 @@
 package com.example.ondongnae.backend.course.controller;
 
-import com.example.ondongnae.backend.course.dto.CourseDetailDto;
-import com.example.ondongnae.backend.course.dto.CourseRecommendResponseDto;
-import com.example.ondongnae.backend.course.dto.OptionAndMarketRequestDto;
-import com.example.ondongnae.backend.course.dto.SelectedOptionDto;
+import com.example.ondongnae.backend.course.dto.*;
 import com.example.ondongnae.backend.course.service.CourseRecommendationService;
 import com.example.ondongnae.backend.course.service.CourseService;
 import com.example.ondongnae.backend.course.service.OptionService;
@@ -29,8 +26,16 @@ public class CourseController {
     private final CourseRecommendationService courseRecommendationService;
     private final CourseService courseService;
 
+    @GetMapping
+    public ResponseEntity<ApiResponse<?>> getRandomCourses(@CookieValue(name="language", required = false) String language) {
+        List<RandomCourseDto> randomCourses = courseService.getRandomCourses(language);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.ok(randomCourses));
+    }
+
+
     @GetMapping("/{courseId}")
-    public ResponseEntity<ApiResponse<?>> getRandomCourses(@CookieValue(name="language", required = false) String language,
+    public ResponseEntity<ApiResponse<?>> getCourseDetail(@CookieValue(name="language", required = false) String language,
                                                            @PathVariable Long courseId) {
         CourseDetailDto courseDetail = courseService.getCourseDetail(courseId, language);
         return ResponseEntity.status(HttpStatus.OK)

--- a/src/main/java/com/example/ondongnae/backend/course/controller/CourseController.java
+++ b/src/main/java/com/example/ondongnae/backend/course/controller/CourseController.java
@@ -1,8 +1,10 @@
 package com.example.ondongnae.backend.course.controller;
 
+import com.example.ondongnae.backend.course.dto.CourseDetailDto;
 import com.example.ondongnae.backend.course.dto.CourseRecommendResponseDto;
 import com.example.ondongnae.backend.course.dto.OptionAndMarketRequestDto;
 import com.example.ondongnae.backend.course.dto.SelectedOptionDto;
+import com.example.ondongnae.backend.course.service.CourseRecommendationService;
 import com.example.ondongnae.backend.course.service.CourseService;
 import com.example.ondongnae.backend.course.service.OptionService;
 import com.example.ondongnae.backend.global.response.ApiResponse;
@@ -24,7 +26,16 @@ public class CourseController {
 
     private final OptionService optionService;
     private final MarketService marketService;
+    private final CourseRecommendationService courseRecommendationService;
     private final CourseService courseService;
+
+    @GetMapping("/{courseId}")
+    public ResponseEntity<ApiResponse<?>> getRandomCourses(@CookieValue(name="language", required = false) String language,
+                                                           @PathVariable Long courseId) {
+        CourseDetailDto courseDetail = courseService.getCourseDetail(courseId, language);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.ok(courseDetail));
+    }
 
     @GetMapping("/options")
     public ResponseEntity<ApiResponse<?>> getOptions(@CookieValue(name="language", required = false) String language) {
@@ -41,7 +52,7 @@ public class CourseController {
     public ResponseEntity<ApiResponse<?>> courseRecommendation(@CookieValue(name="language", required = false) String language,
                                                            @Valid @RequestBody SelectedOptionDto selectedOptionDto) {
         System.out.println("lang" + language);
-        CourseRecommendResponseDto courseRecommendation = courseService.getCourseRecommendationByAI(selectedOptionDto, language);
+        CourseRecommendResponseDto courseRecommendation = courseRecommendationService.getCourseRecommendationByAI(selectedOptionDto, language);
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.ok(courseRecommendation));
 

--- a/src/main/java/com/example/ondongnae/backend/course/controller/CourseController.java
+++ b/src/main/java/com/example/ondongnae/backend/course/controller/CourseController.java
@@ -1,0 +1,38 @@
+package com.example.ondongnae.backend.course.controller;
+
+import com.example.ondongnae.backend.course.dto.OptionAndMarketRequestDto;
+import com.example.ondongnae.backend.course.service.OptionService;
+import com.example.ondongnae.backend.global.response.ApiResponse;
+import com.example.ondongnae.backend.market.service.MarketService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/course")
+public class CourseController {
+
+    private final OptionService optionService;
+    private final MarketService marketService;
+
+    @GetMapping("/options")
+    public ResponseEntity<ApiResponse<?>> getOptions(@CookieValue(name="language", required = false) String language) {
+        List<OptionAndMarketRequestDto> options = optionService.getOptionNames(language);
+        List<OptionAndMarketRequestDto> markets = marketService.getMarketNames(language);
+        Map<String, List<OptionAndMarketRequestDto>> result = new HashMap<>();
+        result.put("market", markets);
+        result.put("option", options);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.ok("시장과 옵션을 모두 불러왔습니다", result));
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/course/controller/CourseController.java
+++ b/src/main/java/com/example/ondongnae/backend/course/controller/CourseController.java
@@ -1,18 +1,18 @@
 package com.example.ondongnae.backend.course.controller;
 
+import com.example.ondongnae.backend.course.dto.CourseRecommendResponseDto;
 import com.example.ondongnae.backend.course.dto.OptionAndMarketRequestDto;
+import com.example.ondongnae.backend.course.dto.SelectedOptionDto;
+import com.example.ondongnae.backend.course.service.CourseService;
 import com.example.ondongnae.backend.course.service.OptionService;
 import com.example.ondongnae.backend.global.response.ApiResponse;
 import com.example.ondongnae.backend.market.service.MarketService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CookieValue;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -24,6 +24,7 @@ public class CourseController {
 
     private final OptionService optionService;
     private final MarketService marketService;
+    private final CourseService courseService;
 
     @GetMapping("/options")
     public ResponseEntity<ApiResponse<?>> getOptions(@CookieValue(name="language", required = false) String language) {
@@ -35,4 +36,16 @@ public class CourseController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiResponse.ok("시장과 옵션을 모두 불러왔습니다", result));
     }
+
+    @PostMapping("/recommend")
+    public ResponseEntity<ApiResponse<?>> courseRecommendation(@CookieValue(name="language", required = false) String language,
+                                                           @Valid @RequestBody SelectedOptionDto selectedOptionDto) {
+        System.out.println("lang" + language);
+        CourseRecommendResponseDto courseRecommendation = courseService.getCourseRecommendationByAI(selectedOptionDto, language);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.ok(courseRecommendation));
+
+    }
+
+
 }

--- a/src/main/java/com/example/ondongnae/backend/course/dto/AICourseRecommendationDataDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/AICourseRecommendationDataDto.java
@@ -1,0 +1,15 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+public class AICourseRecommendationDataDto {
+
+    private String course_title;
+    private String course_long_description;
+    private String course_short_description;
+    private List<AIRecommendedCourseStoreDto> course_store;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/dto/AICourseRecommendationRequestDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/AICourseRecommendationRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AICourseRecommendationRequestDto {
+
+    private String market_name;
+    private String with_option;
+    private String atmosphere_option;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/dto/AICourseRecommendationResponseDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/AICourseRecommendationResponseDto.java
@@ -1,0 +1,12 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Data;
+
+@Data
+public class AICourseRecommendationResponseDto {
+
+    private Boolean success;
+    private AICourseRecommendationDataDto data;
+    private String error;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/dto/AIRecommendedCourseStoreDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/AIRecommendedCourseStoreDto.java
@@ -1,0 +1,12 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Data;
+
+@Data
+public class AIRecommendedCourseStoreDto {
+
+    private int id;
+    private String name;
+    private int order;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/dto/CourseDetailDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/CourseDetailDto.java
@@ -1,0 +1,16 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class CourseDetailDto {
+
+    private String title;
+    private String description;
+    private List<RecommendedCourseStoreDto> recommendedCourseStores;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/dto/CourseRecommendResponseDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/CourseRecommendResponseDto.java
@@ -1,0 +1,13 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class CourseRecommendResponseDto {
+
+    private String storeName;
+    private String longDescription;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/dto/CourseRecommendResponseDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/CourseRecommendResponseDto.java
@@ -3,11 +3,15 @@ package com.example.ondongnae.backend.course.dto;
 import lombok.Builder;
 import lombok.Data;
 
+import java.util.List;
+
 @Data
 @Builder
 public class CourseRecommendResponseDto {
 
-    private String storeName;
-    private String longDescription;
+    private Long id;
+    private String title;
+    private String description;
+    private List<RecommendedCourseStoreDto> recommendedCourseStores;
 
 }

--- a/src/main/java/com/example/ondongnae/backend/course/dto/OptionAndMarketRequestDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/OptionAndMarketRequestDto.java
@@ -1,0 +1,13 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class OptionAndMarketRequestDto {
+
+    private Long id;
+    private String name;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/dto/RandomCourseDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/RandomCourseDto.java
@@ -1,0 +1,17 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class RandomCourseDto {
+
+    private Long id;
+    private String courseTitle;
+    private String courseDescription;
+    private List<String> storeNames;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/dto/RecommendedCourseStoreDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/RecommendedCourseStoreDto.java
@@ -1,0 +1,14 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class RecommendedCourseStoreDto {
+
+    private String name;
+    private String longDescription;
+    private int order;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/dto/RecommendedCourseStoreDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/RecommendedCourseStoreDto.java
@@ -9,6 +9,7 @@ public class RecommendedCourseStoreDto {
 
     private String name;
     private String longDescription;
+    private String shortDescription;
     private long order;
 
 }

--- a/src/main/java/com/example/ondongnae/backend/course/dto/RecommendedCourseStoreDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/RecommendedCourseStoreDto.java
@@ -9,6 +9,6 @@ public class RecommendedCourseStoreDto {
 
     private String name;
     private String longDescription;
-    private int order;
+    private long order;
 
 }

--- a/src/main/java/com/example/ondongnae/backend/course/dto/SelectedOptionDto.java
+++ b/src/main/java/com/example/ondongnae/backend/course/dto/SelectedOptionDto.java
@@ -1,0 +1,12 @@
+package com.example.ondongnae.backend.course.dto;
+
+import lombok.Data;
+
+@Data
+public class SelectedOptionDto {
+
+    private Long marketId;
+    private Long withOptionId;
+    private Long atmosphereOptionId;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/model/Course.java
+++ b/src/main/java/com/example/ondongnae/backend/course/model/Course.java
@@ -10,6 +10,7 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class Course {
 
     @Id
@@ -29,16 +30,28 @@ public class Course {
     private String titleJa;
 
     @Column(nullable = false)
-    private String descriptionKo;
+    private String longDescriptionKo;
 
     @Column(nullable = false)
-    private String descriptionEn;
+    private String longDescriptionEn;
 
     @Column(nullable = false)
-    private String descriptionZh;
+    private String longDescriptionZh;
 
     @Column(nullable = false)
-    private String descriptionJa;
+    private String longDescriptionJa;
+
+    @Column(nullable = false)
+    private String shortDescriptionKo;
+
+    @Column(nullable = false)
+    private String shortDescriptionEn;
+
+    @Column(nullable = false)
+    private String shortDescriptionZh;
+
+    @Column(nullable = false)
+    private String shortDescriptionJa;
 
     @OneToMany(mappedBy = "course")
     private List<CourseStore> courseStores = new ArrayList<>();

--- a/src/main/java/com/example/ondongnae/backend/course/model/Course.java
+++ b/src/main/java/com/example/ondongnae/backend/course/model/Course.java
@@ -29,16 +29,16 @@ public class Course {
     @Column(nullable = false)
     private String titleJa;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String longDescriptionKo;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String longDescriptionEn;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String longDescriptionZh;
 
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "LONGTEXT")
     private String longDescriptionJa;
 
     @Column(nullable = false)

--- a/src/main/java/com/example/ondongnae/backend/course/model/CourseStore.java
+++ b/src/main/java/com/example/ondongnae/backend/course/model/CourseStore.java
@@ -8,6 +8,7 @@ import lombok.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class CourseStore {
 
     @Id

--- a/src/main/java/com/example/ondongnae/backend/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/ondongnae/backend/course/repository/CourseRepository.java
@@ -2,8 +2,15 @@ package com.example.ondongnae.backend.course.repository;
 
 import com.example.ondongnae.backend.course.model.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface CourseRepository extends JpaRepository<Course, Long> {
+
+    @Query(value = "SELECT * FROM course ORDER BY RAND() LIMIT 3", nativeQuery = true)
+    List<Course> pickRandom();
+
 }

--- a/src/main/java/com/example/ondongnae/backend/course/repository/CourseRepository.java
+++ b/src/main/java/com/example/ondongnae/backend/course/repository/CourseRepository.java
@@ -1,10 +1,9 @@
 package com.example.ondongnae.backend.course.repository;
 
-
-import com.example.ondongnae.backend.course.model.Option;
+import com.example.ondongnae.backend.course.model.Course;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface OptionRepository extends JpaRepository<Option, Long> {
+public interface CourseRepository extends JpaRepository<Course, Long> {
 }

--- a/src/main/java/com/example/ondongnae/backend/course/repository/CourseStoreRepository.java
+++ b/src/main/java/com/example/ondongnae/backend/course/repository/CourseStoreRepository.java
@@ -1,0 +1,12 @@
+package com.example.ondongnae.backend.course.repository;
+
+import com.example.ondongnae.backend.course.model.CourseStore;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CourseStoreRepository extends JpaRepository<CourseStore, Long> {
+    List<CourseStore> findByCourseId(Long courseId);
+}

--- a/src/main/java/com/example/ondongnae/backend/course/repository/OptionRepository.java
+++ b/src/main/java/com/example/ondongnae/backend/course/repository/OptionRepository.java
@@ -1,0 +1,10 @@
+package com.example.ondongnae.backend.course.repository;
+
+
+import com.example.ondongnae.backend.course.model.Option;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OptionRepository extends JpaRepository<Option, Integer> {
+}

--- a/src/main/java/com/example/ondongnae/backend/course/service/CourseRecommendationService.java
+++ b/src/main/java/com/example/ondongnae/backend/course/service/CourseRecommendationService.java
@@ -1,0 +1,177 @@
+package com.example.ondongnae.backend.course.service;
+
+import com.example.ondongnae.backend.course.dto.*;
+import com.example.ondongnae.backend.course.model.Course;
+import com.example.ondongnae.backend.course.model.CourseStore;
+import com.example.ondongnae.backend.course.model.Option;
+import com.example.ondongnae.backend.course.repository.CourseRepository;
+import com.example.ondongnae.backend.course.repository.CourseStoreRepository;
+import com.example.ondongnae.backend.course.repository.OptionRepository;
+import com.example.ondongnae.backend.global.dto.TranslateResponseDto;
+import com.example.ondongnae.backend.global.exception.BaseException;
+import com.example.ondongnae.backend.global.exception.ErrorCode;
+import com.example.ondongnae.backend.global.service.LanguageService;
+import com.example.ondongnae.backend.global.service.TranslateService;
+import com.example.ondongnae.backend.market.model.Market;
+import com.example.ondongnae.backend.market.repository.MarketRepository;
+import com.example.ondongnae.backend.store.model.Store;
+import com.example.ondongnae.backend.store.model.StoreIntro;
+import com.example.ondongnae.backend.store.repository.StoreIntroRepository;
+import com.example.ondongnae.backend.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CourseRecommendationService {
+
+    @Value("${COURSE_RECOMMENDATION_API_URL}")
+    private String RECOMMENDATION_API_URL;
+
+    private final StoreIntroRepository storeIntroRepository;
+    private final CourseStoreRepository courseStoreRepository;
+    private final StoreRepository storeRepository;
+    private final OptionRepository optionRepository;
+    private final MarketRepository marketRepository;
+    private final CourseRepository courseRepository;
+    private final TranslateService translateService;
+    private final LanguageService languageService;
+
+    public CourseRecommendResponseDto getCourseRecommendationByAI(SelectedOptionDto selectedOptionDto, String lang) {
+
+        // 코스 생성
+        AICourseRecommendationResponseDto aiCourseRecommendationResponseDto = getCourseRecommendationResponseDto(selectedOptionDto);
+
+        // 코스 번역 및 저장
+        Course course = translateAndSaveRecommendation(aiCourseRecommendationResponseDto);
+
+        // 언어에 따른 코스 추천 반환 -------
+        List<CourseStore> courseStores = courseStoreRepository.findByCourseId(course.getId());
+        String language = lang == null ? "en" : lang.strip().toLowerCase();
+
+        String title = languageService.pickByLang(course.getTitleEn(), course.getTitleJa(), course.getTitleZh(), language);
+        String longDescription = languageService.pickByLang(course.getLongDescriptionEn(), course.getLongDescriptionJa(), course.getLongDescriptionZh(), language);
+        List<RecommendedCourseStoreDto> recommendedCourseStoreDtoList = getRecommendedCourseStoreDtoList(courseStores, language);
+
+        CourseRecommendResponseDto courseRecommendResponseDto = CourseRecommendResponseDto.builder()
+                .recommendedCourseStores(recommendedCourseStoreDtoList)
+                .title(title)
+                .description(longDescription)
+                .id(course.getId())
+                .build();
+
+        return courseRecommendResponseDto;
+    }
+
+    // 언어에 따른 코스 내 가게 정보 가져오기
+    public List<RecommendedCourseStoreDto> getRecommendedCourseStoreDtoList(List<CourseStore> courseStores, String language) {
+        List<RecommendedCourseStoreDto> recommendedCourseStoreDtoList = new ArrayList<>();
+
+        for (CourseStore s : courseStores) {
+            Store store = s.getStore();
+
+            String storeName = languageService.pickByLang(store.getNameEn(), store.getNameJa(), store.getNameZh(), language);
+
+            long order = s.getOrder();
+
+            StoreIntro storeIntro = storeIntroRepository.findFirstByStoreIdAndLang(store.getId(), language).orElse(null);
+            String longIntro = storeIntro.getLongIntro();
+            String shortIntro = storeIntro.getShortIntro();
+
+
+            RecommendedCourseStoreDto dto = RecommendedCourseStoreDto.builder().name(storeName)
+                    .longDescription(longIntro).shortDescription(shortIntro).order(order).build();
+            recommendedCourseStoreDtoList.add(dto);
+        }
+
+        return recommendedCourseStoreDtoList;
+    }
+
+    // 코스 생성
+    private AICourseRecommendationResponseDto getCourseRecommendationResponseDto(SelectedOptionDto selectedOptionDto) {
+        Market market = marketRepository.findById(selectedOptionDto.getMarketId())
+                .orElseThrow(() -> new BaseException(ErrorCode.MARKET_NOT_FOUND, "해당 id의 시장이 존재하지 않습니다"));
+        Option atmosphere = optionRepository.findById(selectedOptionDto.getAtmosphereOptionId())
+                .orElseThrow(() -> new BaseException(ErrorCode.OPTION_NOT_FOUND, "해당 id의 옵션이 존재하지 않습니다."));
+        Option with = optionRepository.findById(selectedOptionDto.getWithOptionId())
+                .orElseThrow(() -> new BaseException(ErrorCode.OPTION_NOT_FOUND, "해당 id의 옵션이 존재하지 않습니다."));
+
+        AICourseRecommendationRequestDto aiCourseRecommendationRequestDto = AICourseRecommendationRequestDto.builder()
+                .market_name(market.getNameKo())
+                .with_option(with.getNameKo())
+                .atmosphere_option(atmosphere.getNameKo())
+                .build();
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<AICourseRecommendationRequestDto> requestEntity = new HttpEntity<>(aiCourseRecommendationRequestDto, headers);
+
+        AICourseRecommendationResponseDto aiCourseRecommendationResponseDto;
+
+        try {
+            aiCourseRecommendationResponseDto = restTemplate.exchange(RECOMMENDATION_API_URL, HttpMethod.POST, requestEntity, AICourseRecommendationResponseDto.class).getBody();
+
+            if (aiCourseRecommendationResponseDto == null)
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API로부터 응답을 받아오지 못했습니다.");
+            if (!aiCourseRecommendationResponseDto.getSuccess())
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 에러 - " + aiCourseRecommendationResponseDto.getError());
+
+        } catch (ResourceAccessException e) {
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 연결에 실패했습니다.");
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API에서 알 수 없는 오류가 발생했습니다.");
+        }
+        return aiCourseRecommendationResponseDto;
+    }
+
+    // 코스 번역 및 저장
+    private Course translateAndSaveRecommendation(AICourseRecommendationResponseDto aiCourseRecommendationResponseDto) {
+
+        AICourseRecommendationDataDto data = aiCourseRecommendationResponseDto.getData();
+        List<AIRecommendedCourseStoreDto> courseStores = data.getCourse_store();
+
+        TranslateResponseDto shortDescription = translateService.translate(data.getCourse_short_description());
+        TranslateResponseDto longDescription = translateService.translate(data.getCourse_long_description());
+        TranslateResponseDto title = translateService.translate(data.getCourse_title());
+
+        Course course = Course.builder().longDescriptionKo(data.getCourse_long_description())
+                .longDescriptionEn(longDescription.getEnglish())
+                .longDescriptionJa(longDescription.getJapanese())
+                .longDescriptionZh(longDescription.getChinese())
+                .shortDescriptionKo(data.getCourse_short_description())
+                .shortDescriptionEn(shortDescription.getEnglish())
+                .shortDescriptionZh(shortDescription.getChinese())
+                .shortDescriptionJa(shortDescription.getJapanese())
+                .titleKo(data.getCourse_title())
+                .titleEn(title.getEnglish())
+                .titleJa(title.getJapanese())
+                .titleZh(title.getChinese())
+                .build();
+
+        Course savedCourse = courseRepository.save(course);
+
+        for (AIRecommendedCourseStoreDto s : courseStores) {
+            Store store = storeRepository.findById((long) s.getId())
+                    .orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND, "해당 id의 가게를 찾을 수 없습니다."));
+            CourseStore courseStore = CourseStore.builder().store(store).course(savedCourse).order(s.getOrder()).build();
+            courseStoreRepository.save(courseStore);
+        }
+
+        return savedCourse;
+    }
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/service/CourseService.java
+++ b/src/main/java/com/example/ondongnae/backend/course/service/CourseService.java
@@ -85,15 +85,12 @@ public class CourseService {
             long order = s.getOrder();
 
             StoreIntro storeIntro = storeIntroRepository.findFirstByStoreIdAndLang(store.getId(), language).orElse(null);
-            String longIntro;
-            try {
-                longIntro = storeIntro.getLongIntro();
-            } catch (NullPointerException e) {
-                longIntro = null;
-            }
+            String longIntro = storeIntro.getLongIntro();
+            String shortIntro = storeIntro.getShortIntro();
+
 
             RecommendedCourseStoreDto dto = RecommendedCourseStoreDto.builder().name(storeName)
-                    .longDescription(longIntro).order(order).build();
+                    .longDescription(longIntro).shortDescription(shortIntro).order(order).build();
             recommendedCourseStoreDtoList.add(dto);
         }
 

--- a/src/main/java/com/example/ondongnae/backend/course/service/CourseService.java
+++ b/src/main/java/com/example/ondongnae/backend/course/service/CourseService.java
@@ -1,0 +1,180 @@
+package com.example.ondongnae.backend.course.service;
+
+import com.example.ondongnae.backend.course.dto.*;
+import com.example.ondongnae.backend.course.model.Course;
+import com.example.ondongnae.backend.course.model.CourseStore;
+import com.example.ondongnae.backend.course.model.Option;
+import com.example.ondongnae.backend.course.repository.CourseRepository;
+import com.example.ondongnae.backend.course.repository.CourseStoreRepository;
+import com.example.ondongnae.backend.course.repository.OptionRepository;
+import com.example.ondongnae.backend.global.dto.TranslateResponseDto;
+import com.example.ondongnae.backend.global.exception.BaseException;
+import com.example.ondongnae.backend.global.exception.ErrorCode;
+import com.example.ondongnae.backend.global.service.LanguageService;
+import com.example.ondongnae.backend.global.service.TranslateService;
+import com.example.ondongnae.backend.market.model.Market;
+import com.example.ondongnae.backend.market.repository.MarketRepository;
+import com.example.ondongnae.backend.store.model.Store;
+import com.example.ondongnae.backend.store.model.StoreIntro;
+import com.example.ondongnae.backend.store.repository.StoreIntroRepository;
+import com.example.ondongnae.backend.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.ResourceAccessException;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CourseService {
+
+    @Value("${COURSE_RECOMMENDATION_API_URL}")
+    private String RECOMMENDATION_API_URL;
+
+    private final StoreIntroRepository storeIntroRepository;
+    private final CourseStoreRepository courseStoreRepository;
+    private final StoreRepository storeRepository;
+    private final OptionRepository optionRepository;
+    private final MarketRepository marketRepository;
+    private final CourseRepository courseRepository;
+    private final TranslateService translateService;
+    private final LanguageService languageService;
+
+    public CourseRecommendResponseDto getCourseRecommendationByAI(SelectedOptionDto selectedOptionDto, String lang) {
+
+        // 코스 생성
+        AICourseRecommendationResponseDto aiCourseRecommendationResponseDto = getCourseRecommendationResponseDto(selectedOptionDto);
+
+        // 코스 번역 및 저장
+        Course course = translateAndSaveRecommendation(aiCourseRecommendationResponseDto);
+
+        // 언어에 따른 코스 추천 반환 -------
+        List<CourseStore> courseStores = courseStoreRepository.findByCourseId(course.getId());
+        String language = lang == null ? "en" : lang.strip().toLowerCase();
+
+        String title = languageService.pickByLang(course.getTitleEn(), course.getTitleJa(), course.getTitleZh(), language);
+        String longDescription = languageService.pickByLang(course.getLongDescriptionEn(), course.getLongDescriptionJa(), course.getLongDescriptionZh(), language);
+        List<RecommendedCourseStoreDto> recommendedCourseStoreDtoList = getRecommendedCourseStoreDtoList(courseStores, language);
+
+        CourseRecommendResponseDto courseRecommendResponseDto = CourseRecommendResponseDto.builder()
+                .recommendedCourseStores(recommendedCourseStoreDtoList)
+                .title(title)
+                .description(longDescription)
+                .id(course.getId())
+                .build();
+
+        return courseRecommendResponseDto;
+    }
+
+    // 언어에 따른 코스 내 가게 정보 가져오기
+    private List<RecommendedCourseStoreDto> getRecommendedCourseStoreDtoList(List<CourseStore> courseStores, String language) {
+        List<RecommendedCourseStoreDto> recommendedCourseStoreDtoList = new ArrayList<>();
+
+        for (CourseStore s : courseStores) {
+            Store store = s.getStore();
+
+            String storeName = languageService.pickByLang(store.getNameEn(), store.getNameJa(), store.getNameZh(), language);
+
+            long order = s.getOrder();
+
+            StoreIntro storeIntro = storeIntroRepository.findFirstByStoreIdAndLang(store.getId(), language).orElse(null);
+            String longIntro;
+            try {
+                longIntro = storeIntro.getLongIntro();
+            } catch (NullPointerException e) {
+                longIntro = null;
+            }
+
+            RecommendedCourseStoreDto dto = RecommendedCourseStoreDto.builder().name(storeName)
+                    .longDescription(longIntro).order(order).build();
+            recommendedCourseStoreDtoList.add(dto);
+        }
+
+        return recommendedCourseStoreDtoList;
+    }
+
+    // 코스 생성
+    private AICourseRecommendationResponseDto getCourseRecommendationResponseDto(SelectedOptionDto selectedOptionDto) {
+        Market market = marketRepository.findById(selectedOptionDto.getMarketId())
+                .orElseThrow(() -> new BaseException(ErrorCode.MARKET_NOT_FOUND, "해당 id의 시장이 존재하지 않습니다"));
+        Option atmosphere = optionRepository.findById(selectedOptionDto.getAtmosphereOptionId())
+                .orElseThrow(() -> new BaseException(ErrorCode.OPTION_NOT_FOUND, "해당 id의 옵션이 존재하지 않습니다."));
+        Option with = optionRepository.findById(selectedOptionDto.getWithOptionId())
+                .orElseThrow(() -> new BaseException(ErrorCode.OPTION_NOT_FOUND, "해당 id의 옵션이 존재하지 않습니다."));
+
+        AICourseRecommendationRequestDto aiCourseRecommendationRequestDto = AICourseRecommendationRequestDto.builder()
+                .market_name(market.getNameKo())
+                .with_option(with.getNameKo())
+                .atmosphere_option(atmosphere.getNameKo())
+                .build();
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        HttpEntity<AICourseRecommendationRequestDto> requestEntity = new HttpEntity<>(aiCourseRecommendationRequestDto, headers);
+
+        AICourseRecommendationResponseDto aiCourseRecommendationResponseDto;
+
+        try {
+            aiCourseRecommendationResponseDto = restTemplate.exchange(RECOMMENDATION_API_URL, HttpMethod.POST, requestEntity, AICourseRecommendationResponseDto.class).getBody();
+
+            if (aiCourseRecommendationResponseDto == null)
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API로부터 응답을 받아오지 못했습니다.");
+            if (!aiCourseRecommendationResponseDto.getSuccess())
+                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 에러 - " + aiCourseRecommendationResponseDto.getError());
+
+        } catch (ResourceAccessException e) {
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 연결에 실패했습니다.");
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API에서 알 수 없는 오류가 발생했습니다.");
+        }
+        return aiCourseRecommendationResponseDto;
+    }
+
+    // 코스 번역 및 저장
+    private Course translateAndSaveRecommendation(AICourseRecommendationResponseDto aiCourseRecommendationResponseDto) {
+
+        AICourseRecommendationDataDto data = aiCourseRecommendationResponseDto.getData();
+        List<AIRecommendedCourseStoreDto> courseStores = data.getCourse_store();
+
+        TranslateResponseDto shortDescription = translateService.translate(data.getCourse_short_description());
+        TranslateResponseDto longDescription = translateService.translate(data.getCourse_long_description());
+        TranslateResponseDto title = translateService.translate(data.getCourse_title());
+
+        Course course = Course.builder().longDescriptionKo(data.getCourse_long_description())
+                .longDescriptionEn(longDescription.getEnglish())
+                .longDescriptionJa(longDescription.getJapanese())
+                .longDescriptionZh(longDescription.getChinese())
+                .shortDescriptionKo(data.getCourse_short_description())
+                .shortDescriptionEn(shortDescription.getEnglish())
+                .shortDescriptionZh(shortDescription.getChinese())
+                .shortDescriptionJa(shortDescription.getJapanese())
+                .titleKo(data.getCourse_title())
+                .titleEn(title.getEnglish())
+                .titleJa(title.getJapanese())
+                .titleZh(title.getChinese())
+                .build();
+
+        Course savedCourse = courseRepository.save(course);
+
+        for (AIRecommendedCourseStoreDto s : courseStores) {
+            Store store = storeRepository.findById((long) s.getId())
+                    .orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND, "해당 id의 가게를 찾을 수 없습니다."));
+            CourseStore courseStore = CourseStore.builder().store(store).course(savedCourse).order(s.getOrder()).build();
+            courseStoreRepository.save(courseStore);
+        }
+
+        return savedCourse;
+    }
+
+}

--- a/src/main/java/com/example/ondongnae/backend/course/service/CourseService.java
+++ b/src/main/java/com/example/ondongnae/backend/course/service/CourseService.java
@@ -1,177 +1,50 @@
 package com.example.ondongnae.backend.course.service;
 
-import com.example.ondongnae.backend.course.dto.*;
+import com.example.ondongnae.backend.course.dto.CourseDetailDto;
+import com.example.ondongnae.backend.course.dto.RecommendedCourseStoreDto;
 import com.example.ondongnae.backend.course.model.Course;
 import com.example.ondongnae.backend.course.model.CourseStore;
-import com.example.ondongnae.backend.course.model.Option;
 import com.example.ondongnae.backend.course.repository.CourseRepository;
 import com.example.ondongnae.backend.course.repository.CourseStoreRepository;
-import com.example.ondongnae.backend.course.repository.OptionRepository;
-import com.example.ondongnae.backend.global.dto.TranslateResponseDto;
 import com.example.ondongnae.backend.global.exception.BaseException;
 import com.example.ondongnae.backend.global.exception.ErrorCode;
 import com.example.ondongnae.backend.global.service.LanguageService;
-import com.example.ondongnae.backend.global.service.TranslateService;
-import com.example.ondongnae.backend.market.model.Market;
-import com.example.ondongnae.backend.market.repository.MarketRepository;
-import com.example.ondongnae.backend.store.model.Store;
-import com.example.ondongnae.backend.store.model.StoreIntro;
-import com.example.ondongnae.backend.store.repository.StoreIntroRepository;
-import com.example.ondongnae.backend.store.repository.StoreRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.ResourceAccessException;
-import org.springframework.web.client.RestTemplate;
 
-import java.util.ArrayList;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class CourseService {
 
-    @Value("${COURSE_RECOMMENDATION_API_URL}")
-    private String RECOMMENDATION_API_URL;
-
-    private final StoreIntroRepository storeIntroRepository;
-    private final CourseStoreRepository courseStoreRepository;
-    private final StoreRepository storeRepository;
-    private final OptionRepository optionRepository;
-    private final MarketRepository marketRepository;
     private final CourseRepository courseRepository;
-    private final TranslateService translateService;
+    private final CourseStoreRepository courseStoreRepository;
+    private final CourseRecommendationService courseRecommendationService;
     private final LanguageService languageService;
 
-    public CourseRecommendResponseDto getCourseRecommendationByAI(SelectedOptionDto selectedOptionDto, String lang) {
+    public CourseDetailDto getCourseDetail(Long courseId, String lang) {
+        // 코스 조회
+        Course course = courseRepository.findById(courseId)
+                .orElseThrow(() -> new BaseException(ErrorCode.COURSE_NOT_FOUND, "해당 id의 코스가 존재하지 않습니다."));
 
-        // 코스 생성
-        AICourseRecommendationResponseDto aiCourseRecommendationResponseDto = getCourseRecommendationResponseDto(selectedOptionDto);
-
-        // 코스 번역 및 저장
-        Course course = translateAndSaveRecommendation(aiCourseRecommendationResponseDto);
-
-        // 언어에 따른 코스 추천 반환 -------
+        // 코스 내 가게 조회
         List<CourseStore> courseStores = courseStoreRepository.findByCourseId(course.getId());
+
+        // 언어에 따라 반환
         String language = lang == null ? "en" : lang.strip().toLowerCase();
 
         String title = languageService.pickByLang(course.getTitleEn(), course.getTitleJa(), course.getTitleZh(), language);
         String longDescription = languageService.pickByLang(course.getLongDescriptionEn(), course.getLongDescriptionJa(), course.getLongDescriptionZh(), language);
-        List<RecommendedCourseStoreDto> recommendedCourseStoreDtoList = getRecommendedCourseStoreDtoList(courseStores, language);
+        List<RecommendedCourseStoreDto> recommendedCourseStoreDtoList = courseRecommendationService.getRecommendedCourseStoreDtoList(courseStores, language);
 
-        CourseRecommendResponseDto courseRecommendResponseDto = CourseRecommendResponseDto.builder()
+        CourseDetailDto courseDetailDto = CourseDetailDto.builder()
                 .recommendedCourseStores(recommendedCourseStoreDtoList)
                 .title(title)
                 .description(longDescription)
-                .id(course.getId())
                 .build();
 
-        return courseRecommendResponseDto;
-    }
-
-    // 언어에 따른 코스 내 가게 정보 가져오기
-    private List<RecommendedCourseStoreDto> getRecommendedCourseStoreDtoList(List<CourseStore> courseStores, String language) {
-        List<RecommendedCourseStoreDto> recommendedCourseStoreDtoList = new ArrayList<>();
-
-        for (CourseStore s : courseStores) {
-            Store store = s.getStore();
-
-            String storeName = languageService.pickByLang(store.getNameEn(), store.getNameJa(), store.getNameZh(), language);
-
-            long order = s.getOrder();
-
-            StoreIntro storeIntro = storeIntroRepository.findFirstByStoreIdAndLang(store.getId(), language).orElse(null);
-            String longIntro = storeIntro.getLongIntro();
-            String shortIntro = storeIntro.getShortIntro();
-
-
-            RecommendedCourseStoreDto dto = RecommendedCourseStoreDto.builder().name(storeName)
-                    .longDescription(longIntro).shortDescription(shortIntro).order(order).build();
-            recommendedCourseStoreDtoList.add(dto);
-        }
-
-        return recommendedCourseStoreDtoList;
-    }
-
-    // 코스 생성
-    private AICourseRecommendationResponseDto getCourseRecommendationResponseDto(SelectedOptionDto selectedOptionDto) {
-        Market market = marketRepository.findById(selectedOptionDto.getMarketId())
-                .orElseThrow(() -> new BaseException(ErrorCode.MARKET_NOT_FOUND, "해당 id의 시장이 존재하지 않습니다"));
-        Option atmosphere = optionRepository.findById(selectedOptionDto.getAtmosphereOptionId())
-                .orElseThrow(() -> new BaseException(ErrorCode.OPTION_NOT_FOUND, "해당 id의 옵션이 존재하지 않습니다."));
-        Option with = optionRepository.findById(selectedOptionDto.getWithOptionId())
-                .orElseThrow(() -> new BaseException(ErrorCode.OPTION_NOT_FOUND, "해당 id의 옵션이 존재하지 않습니다."));
-
-        AICourseRecommendationRequestDto aiCourseRecommendationRequestDto = AICourseRecommendationRequestDto.builder()
-                .market_name(market.getNameKo())
-                .with_option(with.getNameKo())
-                .atmosphere_option(atmosphere.getNameKo())
-                .build();
-
-        RestTemplate restTemplate = new RestTemplate();
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        HttpEntity<AICourseRecommendationRequestDto> requestEntity = new HttpEntity<>(aiCourseRecommendationRequestDto, headers);
-
-        AICourseRecommendationResponseDto aiCourseRecommendationResponseDto;
-
-        try {
-            aiCourseRecommendationResponseDto = restTemplate.exchange(RECOMMENDATION_API_URL, HttpMethod.POST, requestEntity, AICourseRecommendationResponseDto.class).getBody();
-
-            if (aiCourseRecommendationResponseDto == null)
-                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API로부터 응답을 받아오지 못했습니다.");
-            if (!aiCourseRecommendationResponseDto.getSuccess())
-                throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 에러 - " + aiCourseRecommendationResponseDto.getError());
-
-        } catch (ResourceAccessException e) {
-            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API 연결에 실패했습니다.");
-        } catch (BaseException e) {
-            throw e;
-        } catch (Exception e) {
-            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "외부 API에서 알 수 없는 오류가 발생했습니다.");
-        }
-        return aiCourseRecommendationResponseDto;
-    }
-
-    // 코스 번역 및 저장
-    private Course translateAndSaveRecommendation(AICourseRecommendationResponseDto aiCourseRecommendationResponseDto) {
-
-        AICourseRecommendationDataDto data = aiCourseRecommendationResponseDto.getData();
-        List<AIRecommendedCourseStoreDto> courseStores = data.getCourse_store();
-
-        TranslateResponseDto shortDescription = translateService.translate(data.getCourse_short_description());
-        TranslateResponseDto longDescription = translateService.translate(data.getCourse_long_description());
-        TranslateResponseDto title = translateService.translate(data.getCourse_title());
-
-        Course course = Course.builder().longDescriptionKo(data.getCourse_long_description())
-                .longDescriptionEn(longDescription.getEnglish())
-                .longDescriptionJa(longDescription.getJapanese())
-                .longDescriptionZh(longDescription.getChinese())
-                .shortDescriptionKo(data.getCourse_short_description())
-                .shortDescriptionEn(shortDescription.getEnglish())
-                .shortDescriptionZh(shortDescription.getChinese())
-                .shortDescriptionJa(shortDescription.getJapanese())
-                .titleKo(data.getCourse_title())
-                .titleEn(title.getEnglish())
-                .titleJa(title.getJapanese())
-                .titleZh(title.getChinese())
-                .build();
-
-        Course savedCourse = courseRepository.save(course);
-
-        for (AIRecommendedCourseStoreDto s : courseStores) {
-            Store store = storeRepository.findById((long) s.getId())
-                    .orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND, "해당 id의 가게를 찾을 수 없습니다."));
-            CourseStore courseStore = CourseStore.builder().store(store).course(savedCourse).order(s.getOrder()).build();
-            courseStoreRepository.save(courseStore);
-        }
-
-        return savedCourse;
+        return courseDetailDto;
     }
 
 }

--- a/src/main/java/com/example/ondongnae/backend/course/service/OptionService.java
+++ b/src/main/java/com/example/ondongnae/backend/course/service/OptionService.java
@@ -1,0 +1,39 @@
+package com.example.ondongnae.backend.course.service;
+
+import com.example.ondongnae.backend.course.dto.OptionAndMarketRequestDto;
+import com.example.ondongnae.backend.course.model.Option;
+import com.example.ondongnae.backend.course.repository.OptionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class OptionService {
+
+    private final OptionRepository optionRepository;
+
+    public List<OptionAndMarketRequestDto> getOptionNames(String lang) {
+
+        String language = lang == null ? "en" : lang.strip().toLowerCase();
+
+        List<Option> allOptions = optionRepository.findAll();
+        List<OptionAndMarketRequestDto> optionNameAndIdList = new ArrayList<>();
+
+        for (Option o : allOptions) {
+            String name = switch (language) {
+                case "en" -> o.getNameEn();
+                case "zh" ->  o.getNameZh();
+                case "ja" -> o.getNameJa();
+                default -> o.getNameEn();
+            };
+
+            optionNameAndIdList.add(OptionAndMarketRequestDto.builder().name(name).id(o.getId()).build());
+        }
+
+        return optionNameAndIdList;
+    }
+
+}

--- a/src/main/java/com/example/ondongnae/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/ondongnae/backend/global/exception/ErrorCode.java
@@ -39,6 +39,8 @@ public enum ErrorCode {
 
     // 코스 추천 관련
     OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "OPTION_NOT_FOUND", "해당 옵션을 찾을 수 없습니다."),
+    COURSE_NOT_FOUND(HttpStatus.NOT_FOUND, "COURSE_NOT_FOUND", "해당 코스를 찾을 수 없습니다."),
+
     // 환율 관련
 
     // 최종 안전망

--- a/src/main/java/com/example/ondongnae/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/ondongnae/backend/global/exception/ErrorCode.java
@@ -20,7 +20,7 @@ public enum ErrorCode {
     EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED,"EXPIRED_TOKEN","만료된 토큰입니다."),
 
     // 외부 API 관련
-    EXTERNAL_API_ERROR(HttpStatus.BAD_GATEWAY, "EXTERNAL_API_ERROR", "외부 API 연결에 실패했거나 응답이 유효하지 않습니다."),
+    EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL_API_ERROR", "외부 API 연결에 실패했거나 응답이 유효하지 않습니다."),
 
     // 메뉴 관련
 
@@ -38,7 +38,7 @@ public enum ErrorCode {
     // 지도 관련
 
     // 코스 추천 관련
-
+    OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "OPTION_NOT_FOUND", "해당 옵션을 찾을 수 없습니다."),
     // 환율 관련
 
     // 최종 안전망

--- a/src/main/java/com/example/ondongnae/backend/global/service/LanguageService.java
+++ b/src/main/java/com/example/ondongnae/backend/global/service/LanguageService.java
@@ -1,0 +1,27 @@
+package com.example.ondongnae.backend.global.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class LanguageService {
+
+    // 언어 코드에 맞는 문자열 선택 - 한글 포함
+    public String pickByLang(String ko, String en, String ja, String zh, String lang) {
+        return switch (lang) {
+            case "ko" -> ko;
+            case "ja" -> ja;
+            case "zh" -> zh;
+            default -> en;
+        };
+    }
+
+    // 언어 코드에 맞는 문자열 선택 - 한글 포함 X
+    public String pickByLang(String en, String ja, String zh, String lang) {
+        return switch (lang) {
+            case "ja" -> ja;
+            case "zh" -> zh;
+            default -> en;
+        };
+    }
+
+}

--- a/src/main/java/com/example/ondongnae/backend/market/service/MarketService.java
+++ b/src/main/java/com/example/ondongnae/backend/market/service/MarketService.java
@@ -1,0 +1,39 @@
+package com.example.ondongnae.backend.market.service;
+
+import com.example.ondongnae.backend.course.dto.OptionAndMarketRequestDto;
+import com.example.ondongnae.backend.course.model.Option;
+import com.example.ondongnae.backend.market.model.Market;
+import com.example.ondongnae.backend.market.repository.MarketRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+public class MarketService {
+
+    private final MarketRepository marketRepository;
+
+    public MarketService(MarketRepository marketRepository) {
+        this.marketRepository = marketRepository;
+    }
+
+    public List<OptionAndMarketRequestDto> getMarketNames(String lang) {
+
+        String language = lang == null ? "en" : lang.strip().toLowerCase();
+
+        List<Market> allMarket = marketRepository.findAll();
+        List<OptionAndMarketRequestDto> marketNameAndIdList = new ArrayList<>();
+
+        for (Market m : allMarket) {
+            String name = switch (language) {
+                case "en" -> m.getNameEn();
+                case "zh" -> m.getNameZh();
+                case "ja" -> m.getNameJa();
+                default -> m.getNameEn();
+            };
+            marketNameAndIdList.add(OptionAndMarketRequestDto.builder().id(m.getId()).name(name).build());
+        }
+        return marketNameAndIdList;
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/store/dto/AddStoreRequestDto.java
+++ b/src/main/java/com/example/ondongnae/backend/store/dto/AddStoreRequestDto.java
@@ -1,0 +1,17 @@
+package com.example.ondongnae.backend.store.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@Builder
+public class AddStoreRequestDto {
+    private String name;
+    private String description;
+    private String market;
+    private String main_category;
+    private List<String> sub_category;
+    private String address;
+}

--- a/src/main/java/com/example/ondongnae/backend/store/dto/AddStoreRequestDto.java
+++ b/src/main/java/com/example/ondongnae/backend/store/dto/AddStoreRequestDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 @Data
 @Builder
 public class AddStoreRequestDto {
+    private int id;
     private String name;
     private String description;
     private String market;

--- a/src/main/java/com/example/ondongnae/backend/store/dto/AddStoreResponseDto.java
+++ b/src/main/java/com/example/ondongnae/backend/store/dto/AddStoreResponseDto.java
@@ -1,0 +1,10 @@
+package com.example.ondongnae.backend.store.dto;
+
+import lombok.Data;
+
+@Data
+public class AddStoreResponseDto {
+
+    int count;
+
+}

--- a/src/main/java/com/example/ondongnae/backend/store/service/StoreService.java
+++ b/src/main/java/com/example/ondongnae/backend/store/service/StoreService.java
@@ -115,15 +115,15 @@ public class StoreService {
         }
 
         // 벡터 DB에 가게 정보 임베딩
-        embedStore(descriptionCreateRequestDto, descriptionResponseDto, market.getNameKo());
+        embedStore(descriptionCreateRequestDto, descriptionResponseDto, market.getNameKo(), savedStore.getId());
 
         return savedStore.getId();
     }
 
-    private void embedStore(DescriptionCreateRequestDto data, DescriptionResponseDto description, String marketName) {
+    private void embedStore(DescriptionCreateRequestDto data, DescriptionResponseDto description, String marketName, Long storeId) {
 
         AddStoreRequestDto addStoreRequestDto = AddStoreRequestDto.builder().name(data.getName()).description(description.getLong_description())
-                .main_category(data.getMainCategory()).sub_category(data.getSubCategory())
+                .main_category(data.getMainCategory()).sub_category(data.getSubCategory()).id(storeId.intValue())
                 .address(data.getAddress()).market(marketName).build();
 
         RestTemplate restTemplate = new RestTemplate();


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
- CourseController 추가
- CourseRecommendationService 추가 - 코스 추천
   코스 추천 FastAPI에 요청 -> 응답 받아서 가공 후 CourseRecommendResponseDto 반환
- CourseService 추가
    랜덤 코스 조회 + 코스 상세 조회
- 관련 DTO 및 에러 코드 추가
- StoreService 수정
  가게 등록 시 FastAPI에 요청 보내서 가게 임베딩하도록 추가

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
<img width="583" height="679" alt="랜덤 코스 반환" src="https://github.com/user-attachments/assets/a58d75c0-abf8-4689-a388-bdb4ab3ccc42" />
<img width="579" height="667" alt="코스 상세 조회" src="https://github.com/user-attachments/assets/39aa5fcb-187b-4728-9361-8ef012dd6de6" />
<img width="915" height="668" alt="코스 옵션 조회" src="https://github.com/user-attachments/assets/f1f9dc5b-6df7-436d-b9fc-609fe8cf4f54" />
<img width="583" height="635" alt="코스 추천" src="https://github.com/user-attachments/assets/8945e5cc-94e8-4beb-b485-3a74f71d3ec0" />


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
pickByLang 메서드가 자주 쓰일 것 같아서 global/LanguageService에 추가해뒀습니다.
가게 정보 임베딩 요청할 때 가게 id도 저장해두고 반환하도록 했는데 (임베딩은 X), 여기서 반환하는 id로 storeRepository.findById를 하기 때문에 로컬 DB에서 할 경우 오류가 발생할 것 같아요! 배포환경에서는 데이터가 동기화되어서 문제 없을 것 같은데 로컬에서 테스트하실 때 참고하시라고 말씀드립니다!
