### PR TITLE
[Feat] 알레르기 추출 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	implementation 'com.mysql:mysql-connector-j'
 
+	// OpenAI
+	implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+
 	// .env
 	implementation "me.paulschwarz:spring-dotenv:4.0.0"
 

--- a/src/main/java/com/example/ondongnae/backend/allergy/cononical/AllergyCanonicalMapper.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/cononical/AllergyCanonicalMapper.java
@@ -1,0 +1,96 @@
+package com.example.ondongnae.backend.allergy.cononical;
+
+import java.util.Map;
+
+// 캐논명(영문) → 다국어 라벨 매핑 유틸.
+public final class AllergyCanonicalMapper {
+    private AllergyCanonicalMapper() {}
+
+    // ko 매핑 (필요 시 DB/설정으로 이동)
+    private static final Map<CanonicalAllergy, String> KO = Map.ofEntries(
+            Map.entry(CanonicalAllergy.EGGS, "알류(계란)"),
+            Map.entry(CanonicalAllergy.MILK, "우유"),
+            Map.entry(CanonicalAllergy.BUCKWHEAT, "메밀"),
+            Map.entry(CanonicalAllergy.PEANUTS, "땅콩"),
+            Map.entry(CanonicalAllergy.SOY, "대두"),
+            Map.entry(CanonicalAllergy.WHEAT_GLUTEN, "밀(글루텐)"),
+            Map.entry(CanonicalAllergy.MACKEREL, "고등어"),
+            Map.entry(CanonicalAllergy.CRAB, "게"),
+            Map.entry(CanonicalAllergy.SHRIMP, "새우"),
+            Map.entry(CanonicalAllergy.PORK, "돼지고기"),
+            Map.entry(CanonicalAllergy.PEACH, "복숭아"),
+            Map.entry(CanonicalAllergy.TOMATO, "토마토"),
+            Map.entry(CanonicalAllergy.SULFITES, "아황산류"),
+            Map.entry(CanonicalAllergy.WALNUTS, "호두"),
+            Map.entry(CanonicalAllergy.CHICKEN, "닭고기"),
+            Map.entry(CanonicalAllergy.BEEF, "소고기"),
+            Map.entry(CanonicalAllergy.SQUID, "오징어"),
+            Map.entry(CanonicalAllergy.SHELLFISH, "조개류"),
+            Map.entry(CanonicalAllergy.PINE_NUTS, "잣"),
+            Map.entry(CanonicalAllergy.FISH, "생선"),
+            Map.entry(CanonicalAllergy.SESAME, "참깨"),
+            Map.entry(CanonicalAllergy.DAIRY, "유제품"),
+            Map.entry(CanonicalAllergy.TREE_NUTS, "견과류"),
+            Map.entry(CanonicalAllergy.CRUSTACEANS, "갑각류")
+    );
+
+    // ja 매핑
+    private static final Map<CanonicalAllergy, String> JA = Map.ofEntries(
+            Map.entry(CanonicalAllergy.EGGS, "卵"),
+            Map.entry(CanonicalAllergy.MILK, "乳"),
+            Map.entry(CanonicalAllergy.BUCKWHEAT, "そば"),
+            Map.entry(CanonicalAllergy.PEANUTS, "落花生"),
+            Map.entry(CanonicalAllergy.SOY, "大豆"),
+            Map.entry(CanonicalAllergy.WHEAT_GLUTEN, "小麦(グルテン)"),
+            Map.entry(CanonicalAllergy.MACKEREL, "サバ"),
+            Map.entry(CanonicalAllergy.CRAB, "カニ"),
+            Map.entry(CanonicalAllergy.SHRIMP, "エビ"),
+            Map.entry(CanonicalAllergy.PORK, "豚肉"),
+            Map.entry(CanonicalAllergy.PEACH, "もも"),
+            Map.entry(CanonicalAllergy.TOMATO, "トマト"),
+            Map.entry(CanonicalAllergy.SULFITES, "亜硫酸塩"),
+            Map.entry(CanonicalAllergy.WALNUTS, "くるみ"),
+            Map.entry(CanonicalAllergy.CHICKEN, "鶏肉"),
+            Map.entry(CanonicalAllergy.BEEF, "牛肉"),
+            Map.entry(CanonicalAllergy.SQUID, "いか"),
+            Map.entry(CanonicalAllergy.SHELLFISH, "貝類"),
+            Map.entry(CanonicalAllergy.PINE_NUTS, "松の実"),
+            Map.entry(CanonicalAllergy.FISH, "魚"),
+            Map.entry(CanonicalAllergy.SESAME, "ごま"),
+            Map.entry(CanonicalAllergy.DAIRY, "乳製品"),
+            Map.entry(CanonicalAllergy.TREE_NUTS, "木の実"),
+            Map.entry(CanonicalAllergy.CRUSTACEANS, "甲殻類")
+    );
+
+    // zh 매핑
+    private static final Map<CanonicalAllergy, String> ZH = Map.ofEntries(
+            Map.entry(CanonicalAllergy.EGGS, "鸡蛋"),
+            Map.entry(CanonicalAllergy.MILK, "牛奶"),
+            Map.entry(CanonicalAllergy.BUCKWHEAT, "荞麦"),
+            Map.entry(CanonicalAllergy.PEANUTS, "花生"),
+            Map.entry(CanonicalAllergy.SOY, "大豆"),
+            Map.entry(CanonicalAllergy.WHEAT_GLUTEN, "小麦（麸质）"),
+            Map.entry(CanonicalAllergy.MACKEREL, "青花鱼"),
+            Map.entry(CanonicalAllergy.CRAB, "蟹"),
+            Map.entry(CanonicalAllergy.SHRIMP, "虾"),
+            Map.entry(CanonicalAllergy.PORK, "猪肉"),
+            Map.entry(CanonicalAllergy.PEACH, "桃子"),
+            Map.entry(CanonicalAllergy.TOMATO, "番茄"),
+            Map.entry(CanonicalAllergy.SULFITES, "亚硫酸盐"),
+            Map.entry(CanonicalAllergy.WALNUTS, "核桃"),
+            Map.entry(CanonicalAllergy.CHICKEN, "鸡肉"),
+            Map.entry(CanonicalAllergy.BEEF, "牛肉"),
+            Map.entry(CanonicalAllergy.SQUID, "鱿鱼"),
+            Map.entry(CanonicalAllergy.SHELLFISH, "贝类"),
+            Map.entry(CanonicalAllergy.PINE_NUTS, "松子"),
+            Map.entry(CanonicalAllergy.FISH, "鱼"),
+            Map.entry(CanonicalAllergy.SESAME, "芝麻"),
+            Map.entry(CanonicalAllergy.DAIRY, "乳制品"),
+            Map.entry(CanonicalAllergy.TREE_NUTS, "坚果"),
+            Map.entry(CanonicalAllergy.CRUSTACEANS, "甲壳类")
+    );
+
+    public static String ko(CanonicalAllergy c) { return KO.get(c); }
+    public static String ja(CanonicalAllergy c) { return JA.get(c); }
+    public static String zh(CanonicalAllergy c) { return ZH.get(c); }
+}

--- a/src/main/java/com/example/ondongnae/backend/allergy/cononical/CanonicalAllergy.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/cononical/CanonicalAllergy.java
@@ -1,0 +1,56 @@
+package com.example.ondongnae.backend.allergy.cononical;
+
+import java.util.Arrays;
+import java.util.List;
+
+
+/**
+ * 허용 알레르기 "캐논명(영문)" 목록을 정의하는 enum
+ * 모델(GPT)은 반드시 여기 정의된 labelEn 중에서만 선택하도록 프롬프트/검증으로 강제함
+ */
+public enum CanonicalAllergy {
+    EGGS("Eggs"),
+    MILK("Milk"),
+    BUCKWHEAT("Buckwheat"),
+    PEANUTS("Peanuts"),
+    SOY("Soy"),
+    WHEAT_GLUTEN("Wheat"),
+    MACKEREL("Mackerel"),
+    CRAB("Crab"),
+    SHRIMP("Shrimp"),
+    PORK("Pork"),
+    PEACH("Peach"),
+    TOMATO("Tomato"),
+    SULFITES("Sulfites"),
+    WALNUTS("Walnuts"),
+    CHICKEN("Chicken"),
+    BEEF("Beef"),
+    SQUID("Squid"),
+    SHELLFISH("Shellfish"),
+    PINE_NUTS("Pine Nuts"),
+    FISH("Fish"),
+    SESAME("Sesame"),
+    DAIRY("Dairy"),
+    TREE_NUTS("Tree Nuts"),
+    CRUSTACEANS("Crustaceans");
+
+    private final String labelEn;
+
+    CanonicalAllergy(String labelEn) { this.labelEn = labelEn; }
+
+    // 캐논면(영문) 반환
+    public String labelEn() { return labelEn; }
+
+    // 프롬프트/검증에서 사용할 전체 캐논명(영문) 리스트
+    public static List<String> allEnglishLabels() {
+        return Arrays.stream(values()).map(CanonicalAllergy::labelEn).toList();
+    }
+
+    // 영문 라벨로 enum 역매핑(대소문자 무시)
+    public static CanonicalAllergy fromEnglish(String s) {
+        for (var c : values()) {
+            if (c.labelEn.equalsIgnoreCase(s.trim())) return c;
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/allergy/controller/AllergyController.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/controller/AllergyController.java
@@ -1,0 +1,22 @@
+package com.example.ondongnae.backend.allergy.controller;
+
+import com.example.ondongnae.backend.allergy.dto.AllergyExtractResponse;
+import com.example.ondongnae.backend.allergy.service.AllergyService;
+import com.example.ondongnae.backend.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class AllergyController {
+
+    private final AllergyService allergyService;
+
+    // 알레르기 추출(미리보기) — 본문 없이 호출
+    @PostMapping("/me/menus/allergens/extract")
+    public ResponseEntity<ApiResponse<AllergyExtractResponse>> extract() {
+        var result = allergyService.extractAllFromMyMenus();
+        return ResponseEntity.ok(ApiResponse.ok("알레르기 추출 성공", result));
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/allergy/dto/AllergyExtractResponse.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/dto/AllergyExtractResponse.java
@@ -1,0 +1,30 @@
+package com.example.ondongnae.backend.allergy.dto;
+
+import java.util.List;
+
+public final class AllergyExtractResponse {
+    private final List<Item> results;
+
+    public AllergyExtractResponse(List<Item> results) {
+        this.results = (results == null) ? List.of() : List.copyOf(results); // 불변화
+    }
+
+    public List<Item> getResults() { return results; }
+
+    // 결과의 단일 행(메뉴 1개)의 스냅샷
+    public static final class Item {
+        private final Long menuId;
+        private final String nameKo;
+        private final List<String> allergiesCanonical; // 캐논명(영문) 리스트
+
+        public Item(Long menuId, String nameKo, List<String> allergiesCanonical) {
+            this.menuId = menuId;
+            this.nameKo = nameKo;
+            this.allergiesCanonical = (allergiesCanonical == null)
+                    ? List.of() : List.copyOf(allergiesCanonical);
+        }
+        public Long getMenuId() { return menuId; }
+        public String getNameKo() { return nameKo; }
+        public List<String> getAllergiesCanonical() { return allergiesCanonical; }
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/allergy/gpt/AllergyGptClient.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/gpt/AllergyGptClient.java
@@ -1,0 +1,159 @@
+package com.example.ondongnae.backend.allergy.gpt;
+
+import com.example.ondongnae.backend.allergy.cononical.CanonicalAllergy;
+import com.example.ondongnae.backend.global.exception.BaseException;
+import com.example.ondongnae.backend.global.exception.ErrorCode;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import okhttp3.*;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.*;
+
+
+/**
+ * OpenAI Chat Completions 호출 래퍼
+ * 허용 캐논명(영문) 화이트리스트를 system 프롬프트에 명시
+ * response_format=json_object 로 JSON만 출력하도록 강제
+ * 사후 검증: 허용 목록 밖 값은 버림
+ */
+@Component
+@RequiredArgsConstructor
+public class AllergyGptClient {
+
+    @Value("${openai.api.key}")
+    private String openaiApiKey;
+
+    @Value("${openai.model:gpt-4o-mini}")
+    private String model;
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    // 허용 캐논명(영문)
+    private static final List<String> ALLOWED_CANON = CanonicalAllergy.allEnglishLabels();
+
+    /**
+     * inputs: [{menuId, nameKo, nameEn, cleanKo}, ...]
+     * return: menuId -> [canonical(English), ...]
+     */
+    public Map<Long, List<String>> extractCanonical(List<Map<String, Object>> inputs) {
+        try {
+            // 1. 프롬프트 구성
+            String system = """
+                You are an expert at identifying food allergens in Korean market menu items.
+                Choose allergens ONLY from the allowed canonical list (English):
+                %s
+                If uncertain, return an empty array [].
+                Use provided 'hints' (e.g., NOODLE, FRIED_OR_BATTER) to better infer typical hidden ingredients.
+                Respond STRICTLY in JSON with this schema:
+                {"results":[{"menuId":<long>,"allergiesCanonical":[<string>, ...]}, ...]}
+                """.formatted(ALLOWED_CANON);
+
+            String user = buildUserPrompt(inputs);
+
+            // 2. OpenAI 호출
+            OkHttpClient client = new OkHttpClient.Builder()
+                    .callTimeout(Duration.ofSeconds(40))
+                    .build();
+
+            String payload = """
+            {
+              "model": "%s",
+              "temperature": 0.0,
+              "response_format": {"type":"json_object"},
+              "messages": [
+                {"role":"system","content": %s},
+                {"role":"user","content": %s}
+              ]
+            }
+            """.formatted(model, toJson(system), toJson(user));
+
+            Request request = new Request.Builder()
+                    .url("https://api.openai.com/v1/chat/completions")
+                    .header("Authorization", "Bearer " + openaiApiKey)
+                    .header("Content-Type", "application/json")
+                    .post(RequestBody.create(payload, MediaType.parse("application/json")))
+                    .build();
+
+            // 3. 응답 파싱 + 사후 검증
+            try (Response resp = client.newCall(request).execute()) {
+                if (!resp.isSuccessful()) {
+                    // OpenAI HTTP 에러 -> 게이트웨이 오류로 승격
+                    throw new BaseException(ErrorCode.GPT_PROVIDER_ERROR, "HTTP " + resp.code());
+                }
+                String body = Objects.requireNonNull(resp.body()).string();
+                String content = om.readTree(body)
+                        .path("choices").get(0)
+                        .path("message").path("content").asText();
+
+                JsonNode json = om.readTree(content);
+                Map<Long, List<String>> out = new HashMap<>();
+
+                for (JsonNode item : json.path("results")) {
+                    long id = item.path("menuId").asLong();
+                    List<String> arr = new ArrayList<>();
+                    for (JsonNode a : item.path("allergiesCanonical")) {
+                        String canon = a.asText().trim();
+                        if (ALLOWED_CANON.contains(canon)) arr.add(canon); // 허용 캐논만 통과
+                    }
+                    out.put(id, Collections.unmodifiableList(arr));
+                }
+                return out;
+            }
+        } catch (BaseException e) {
+            throw e;
+        } catch (Exception e) {
+            // 모델이 JSON 스키마를 지키지 못한 경우 등
+            throw new BaseException(ErrorCode.GPT_BAD_RESPONSE, e.getMessage());
+        }
+    }
+
+    // few-shot + 실제 입력을 결합한 user 메시지 구축
+    private String buildUserPrompt(List<Map<String, Object>> inputs) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("""
+        [few-shot]
+        Input:
+        - menuId: 1, ko: "떡볶이", en: "Tteokbokki", cleanKo: "떡볶이", hints: [NOODLE]
+        Output:
+        {"results":[{"menuId":1,"allergiesCanonical":["Wheat (Gluten)"]}]}
+    
+        Input:
+        - menuId: 2, ko: "오징어튀김(대)", en: "Fried squid (L)", cleanKo: "오징어튀김", hints: [FRIED_OR_BATTER, SQUID]
+        Output:
+        {"results":[{"menuId":2,"allergiesCanonical":["Squid","Wheat (Gluten)"]}]}
+    
+        Input:
+        - menuId: 3, ko: "콩국수", en: "Soy Milk Noodles", cleanKo: "콩국수", hints: [NOODLE, SOY]
+        Output:
+        {"results":[{"menuId":3,"allergiesCanonical":["Soy","Wheat (Gluten)"]}]}
+    
+        [Actual Input]
+        """);
+        for (var m : inputs) {
+            sb.append("- menuId: ").append(m.get("menuId"))
+                    .append(", ko: \"").append(m.get("nameKo")).append("\"")
+                    .append(", en: \"").append(m.get("nameEn")).append("\"")
+                    .append(", cleanKo: \"").append(m.get("cleanKo")).append("\"");
+            @SuppressWarnings("unchecked")
+            List<String> hints = (List<String>) m.get("hints");
+            if (hints != null && !hints.isEmpty()) {
+                sb.append(", hints: ").append(hints);
+            }
+            sb.append("\n");
+        }
+        sb.append("""
+    
+        Return JSON only with:
+        {"results":[{"menuId":<long>,"allergiesCanonical":[<string>, ...]}, ...]}
+        """);
+        return sb.toString();
+    }
+
+    private String toJson(String s) {
+        try { return om.writeValueAsString(s); } catch (Exception e) { return "\"\""; }
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/allergy/heuristic/DishTag.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/heuristic/DishTag.java
@@ -1,0 +1,17 @@
+package com.example.ondongnae.backend.allergy.heuristic;
+
+// 메뉴명에서 추출하는 조리/식품 태그
+public enum DishTag {
+    NOODLE,         // 국수/면/라면/우동/소바/짜장면/칼국수/파스타...
+    RICE_NOODLE,    // 쌀국수/pho/rice noodle
+    BUCKWHEAT_BASE, // 메밀/소바/soba/buckwheat
+    FRIED_OR_BATTER,// 튀김/전/부침/tempura/fried/batter/breaded
+    CUTLET,         // 돈까스/카츠/katsu/tonkatsu/cutlet
+    DUMPLING,       // 만두/gyoza/dumpling/mandu
+    SEAFOOD,        // 해물/해산물
+    SQUID, SHRIMP, CRAB, SHELLFISH, FISH, MACKEREL,
+    PORK, BEEF, CHICKEN,
+    EGG,            // 계란/달걀/egg/tamago
+    SOY,            // 콩/두부/간장/된장/soy/tofu
+    SESAME          // 참깨/깨/sesame
+}

--- a/src/main/java/com/example/ondongnae/backend/allergy/heuristic/HeuristicAllergyEngine.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/heuristic/HeuristicAllergyEngine.java
@@ -1,0 +1,142 @@
+package com.example.ondongnae.backend.allergy.heuristic;
+
+import com.example.ondongnae.backend.allergy.cononical.CanonicalAllergy;
+
+import java.util.*;
+import java.util.regex.Pattern;
+
+import static com.example.ondongnae.backend.allergy.cononical.CanonicalAllergy.*;
+
+
+/**
+ * 메뉴 텍스트에서 태그를 뽑고, 태그 기반으로 확정적/통계적 알레르기를 유추한다.
+ * - 결과는 "캐논명(영문)" 기준.
+ * - GPT와 독립적으로 동작하며, 최종 결과는 (휴리스틱 ∪ GPT)로 합친다.
+ */
+public final class HeuristicAllergyEngine {
+
+    private HeuristicAllergyEngine(){}
+
+    // ===== 키워드 패턴 =====
+    private static final Pattern P_NOODLE = Pattern.compile(
+            "(국수|면|우동|라면|소바|짜장면|짬뽕|칼국수|비빔국수|냉면|ramen|udon|soba|noodle|pasta)",
+            Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_RICE_NOODLE = Pattern.compile("(쌀국수|pho|rice\\s*noodle)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_BUCKWHEAT = Pattern.compile("(메밀|소바|soba|buckwheat)", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern P_FRIED = Pattern.compile("(튀김|전|부침|tempura|fried|batter|breaded)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_CUTLET = Pattern.compile("(돈까스|카츠|katsu|tonkatsu|cutlet)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_DUMPLING = Pattern.compile("(만두|gyoza|dumpling|mandu)", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern P_EGG = Pattern.compile("(계란|달걀|egg|tamago)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_SESAME = Pattern.compile("(참깨|\\b깨\\b|sesame)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_SOY = Pattern.compile("(콩|두부|soy|tofu|간장|된장|춘장)", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern P_SQUID = Pattern.compile("(오징어|squid)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_SHRIMP = Pattern.compile("(새우|shrimp)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_CRAB = Pattern.compile("(게\\b|crab)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_SHELLFISH = Pattern.compile("(조개|바지락|홍합|shellfish|clam|mussel|scallop)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_FISH = Pattern.compile("(어묵|생선|fish|가자미|명태|연어)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_MACKEREL = Pattern.compile("(고등어|mackerel)", Pattern.CASE_INSENSITIVE);
+
+    private static final Pattern P_PORK = Pattern.compile("(돼지|돼지고기|pork|tonkatsu)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_BEEF = Pattern.compile("(소고기|beef)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern P_CHICKEN = Pattern.compile("(닭|닭고기|chicken)", Pattern.CASE_INSENSITIVE);
+
+    /** 분석 결과(태그 + 휴리스틱 알레르기) */
+    public static final class Result {
+        private final Set<DishTag> tags;
+        private final Set<CanonicalAllergy> allergens;
+
+        public Result(Set<DishTag> tags, Set<CanonicalAllergy> allergens) {
+            this.tags = Collections.unmodifiableSet(tags);
+            this.allergens = Collections.unmodifiableSet(allergens);
+        }
+        public Set<DishTag> tags() { return tags; }
+        public Set<CanonicalAllergy> allergens() { return allergens; }
+    }
+
+    /** 텍스트에서 태그 추출 → 태그 기반 알레르기 유추 */
+    public static Result analyze(String nameKo, String nameEn, String cleanKo) {
+        String text = String.join(" ", safe(nameKo), safe(nameEn), safe(cleanKo));
+
+        // 1) 태그 추출
+        Set<DishTag> tags = new HashSet<>();
+        if (P_NOODLE.matcher(text).find()) tags.add(DishTag.NOODLE);
+        if (P_RICE_NOODLE.matcher(text).find()) tags.add(DishTag.RICE_NOODLE);
+        if (P_BUCKWHEAT.matcher(text).find()) tags.add(DishTag.BUCKWHEAT_BASE);
+
+        if (P_FRIED.matcher(text).find()) tags.add(DishTag.FRIED_OR_BATTER);
+        if (P_CUTLET.matcher(text).find()) tags.add(DishTag.CUTLET);
+        if (P_DUMPLING.matcher(text).find()) tags.add(DishTag.DUMPLING);
+
+        if (P_EGG.matcher(text).find()) tags.add(DishTag.EGG);
+        if (P_SESAME.matcher(text).find()) tags.add(DishTag.SESAME);
+        if (P_SOY.matcher(text).find()) tags.add(DishTag.SOY);
+
+        if (P_SQUID.matcher(text).find()) tags.add(DishTag.SQUID);
+        if (P_SHRIMP.matcher(text).find()) tags.add(DishTag.SHRIMP);
+        if (P_CRAB.matcher(text).find()) tags.add(DishTag.CRAB);
+        if (P_SHELLFISH.matcher(text).find()) tags.add(DishTag.SHELLFISH);
+        if (P_FISH.matcher(text).find()) tags.add(DishTag.FISH);
+        if (P_MACKEREL.matcher(text).find()) tags.add(DishTag.MACKEREL);
+
+        if (P_PORK.matcher(text).find()) tags.add(DishTag.PORK);
+        if (P_BEEF.matcher(text).find()) tags.add(DishTag.BEEF);
+        if (P_CHICKEN.matcher(text).find()) tags.add(DishTag.CHICKEN);
+
+        // 2) 태그 → 휴리스틱 알레르기 매핑
+        Set<CanonicalAllergy> out = new HashSet<>();
+
+        // 면류 기본: 글루텐. 단, 쌀국수는 제외
+        if (tags.contains(DishTag.NOODLE) && !tags.contains(DishTag.RICE_NOODLE)) {
+            out.add(WHEAT_GLUTEN);
+        }
+        // 메밀(소바): Buckwheat. 한국/일본 다수 제품은 밀 혼합 → 보수적으로 글루텐도 함께
+        if (tags.contains(DishTag.BUCKWHEAT_BASE)) {
+            out.add(BUCKWHEAT);
+            out.add(WHEAT_GLUTEN);
+        }
+        // 튀김/전/부침/빵가루: 글루텐
+        if (tags.contains(DishTag.FRIED_OR_BATTER) || tags.contains(DishTag.CUTLET) || tags.contains(DishTag.DUMPLING)) {
+            out.add(WHEAT_GLUTEN);
+        }
+        // 돈까스: 돼지고기 + 글루텐 + (종종) 계란
+        if (tags.contains(DishTag.CUTLET)) {
+            out.add(PORK);
+            out.add(WHEAT_GLUTEN);
+            out.add(EGGS);
+        }
+        // 만두: 보편적으로 밀피(글루텐)
+        if (tags.contains(DishTag.DUMPLING)) {
+            out.add(WHEAT_GLUTEN);
+        }
+        // 콩/두부/간장/된장: 대두
+        if (tags.contains(DishTag.SOY)) {
+            out.add(SOY);
+        }
+        // 참깨: Sesame
+        if (tags.contains(DishTag.SESAME)) {
+            out.add(SESAME);
+        }
+        // 개별 해산물
+        if (tags.contains(DishTag.SQUID)) out.add(SQUID);
+        if (tags.contains(DishTag.SHRIMP)) out.add(SHRIMP);
+        if (tags.contains(DishTag.CRAB)) out.add(CRAB);
+        if (tags.contains(DishTag.SHELLFISH)) out.add(SHELLFISH);
+        if (tags.contains(DishTag.FISH)) out.add(FISH);
+        if (tags.contains(DishTag.MACKEREL)) out.add(MACKEREL);
+
+        // 육류
+        if (tags.contains(DishTag.PORK)) out.add(PORK);
+        if (tags.contains(DishTag.BEEF)) out.add(BEEF);
+        if (tags.contains(DishTag.CHICKEN)) out.add(CHICKEN);
+
+        // 계란
+        if (tags.contains(DishTag.EGG)) out.add(EGGS);
+
+        return new Result(tags, out);
+    }
+
+    private static String safe(String s){ return (s==null)?"":s; }
+}

--- a/src/main/java/com/example/ondongnae/backend/allergy/repository/AllergyRepository.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/repository/AllergyRepository.java
@@ -1,0 +1,7 @@
+package com.example.ondongnae.backend.allergy.repository;
+
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AllergyRepository {
+}

--- a/src/main/java/com/example/ondongnae/backend/allergy/service/AllergyService.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/service/AllergyService.java
@@ -1,0 +1,86 @@
+package com.example.ondongnae.backend.allergy.service;
+
+import com.example.ondongnae.backend.allergy.cononical.CanonicalAllergy;
+import com.example.ondongnae.backend.allergy.dto.AllergyExtractResponse;
+import com.example.ondongnae.backend.allergy.gpt.AllergyGptClient;
+import com.example.ondongnae.backend.allergy.heuristic.HeuristicAllergyEngine;
+import com.example.ondongnae.backend.allergy.util.MenuNamePreprocessor;
+import com.example.ondongnae.backend.global.exception.BaseException;
+import com.example.ondongnae.backend.global.exception.ErrorCode;
+import com.example.ondongnae.backend.member.service.AuthService;
+import com.example.ondongnae.backend.menu.model.Menu;
+import com.example.ondongnae.backend.menu.repository.MenuRepository;
+import com.example.ondongnae.backend.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class AllergyService {
+
+    private final AuthService authService;
+    private final StoreRepository storeRepository;
+    private final MenuRepository menuRepository;
+    private final AllergyGptClient gptClient;
+
+    // 알레르기 추출 실행
+    // 내 가게 모든 메뉴 전처리 -> GPT 추출 -> 응답 DTO 조립
+    @Transactional(readOnly = true)
+    public AllergyExtractResponse extractAllFromMyMenus() {
+        Long storeId = authService.getMyStoreId();
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND));
+
+        List<Menu> menus = menuRepository.findByStoreId(storeId);
+        if (menus.isEmpty()) {
+            return new AllergyExtractResponse(List.of());
+        }
+
+        // 1) 휴리스틱 분석 + GPT 입력 구성
+        Map<Long, HeuristicAllergyEngine.Result> heuristics = new HashMap<>();
+        var inputs = new ArrayList<Map<String,Object>>();
+
+        for (Menu m : menus) {
+            var h = HeuristicAllergyEngine.analyze(m.getNameKo(), m.getNameEn(), MenuNamePreprocessor.clean(m.getNameKo()));
+            heuristics.put(m.getId(), h);
+
+            // 힌트(태그) 문자열화
+            List<String> hintList = h.tags().stream().map(Enum::name).toList();
+
+            inputs.add(Map.of(
+                    "menuId", m.getId(),
+                    "nameKo", m.getNameKo(),
+                    "nameEn", nvl(m.getNameEn(), m.getNameKo()),
+                    "cleanKo", MenuNamePreprocessor.clean(m.getNameKo()),
+                    "hints", hintList
+            ));
+        }
+
+        // 2) GPT 호출
+        Map<Long, List<String>> canonByMenu = gptClient.extractCanonical(inputs);
+
+        // 3) (휴리스틱 ∪ GPT) 결합
+        var items = menus.stream().map(m -> {
+            var h = heuristics.get(m.getId());
+            Set<String> union = new LinkedHashSet<>();
+
+            // 휴리스틱 결과 추가
+            for (CanonicalAllergy c : h.allergens()) union.add(c.labelEn());
+            // GPT 결과 추가
+            union.addAll(canonByMenu.getOrDefault(m.getId(), List.of()));
+
+            return new AllergyExtractResponse.Item(
+                    m.getId(),
+                    m.getNameKo(),
+                    List.copyOf(union)
+            );
+        }).toList();
+
+        return new AllergyExtractResponse(items);
+    }
+
+    private String nvl(String v, String fb) { return (v == null || v.isBlank()) ? fb : v; }
+}

--- a/src/main/java/com/example/ondongnae/backend/allergy/util/MenuNamePreprocessor.java
+++ b/src/main/java/com/example/ondongnae/backend/allergy/util/MenuNamePreprocessor.java
@@ -1,0 +1,34 @@
+package com.example.ondongnae.backend.allergy.util;
+
+/**
+ * 메뉴명 전처리 유틸
+ * 가격/수량/사이즈/괄호/이모지/특수문자 제거
+ * 공백 정규화
+ * 모델이 핵심 키워드(재료/조리법 등)에 집중하도록 노이즈를 제거함
+ */
+public final class MenuNamePreprocessor {
+    private MenuNamePreprocessor() {}
+
+    public static String clean(String src) {
+        if (src == null) return "";
+        String s = src;
+
+        // 가격: "5,000원" 등 제거
+        s = s.replaceAll("\\d{1,3}(,\\d{3})*\\s*원", " ");
+        // 수량: "2개/2 pcs/2장/2인분/2팩" 등 제거
+        s = s.replaceAll("\\d+\\s*(개|pcs|장|인분|팩)", " ");
+        // 사이즈: L/M/S/대/중/소 제거
+        s = s.replaceAll("\\b(L|M|S|대|중|소)\\b", " ");
+
+        // 괄호 내용 제거
+        s = s.replaceAll("\\(.*?\\)", " ");
+        s = s.replaceAll("\\[.*?\\]", " ");
+
+        // 이모지/특수문자 제거(한글/영문/숫자/공백/일부기호만 남김)
+        s = s.replaceAll("[^\\p{IsHangul}\\p{Alnum}\\s/·-]", " ");
+
+        // 공백 정규화
+        s = s.replaceAll("\\s+", " ").trim();
+        return s;
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/ondongnae/backend/global/exception/ErrorCode.java
@@ -21,8 +21,13 @@ public enum ErrorCode {
 
     // 외부 API 관련
     EXTERNAL_API_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "EXTERNAL_API_ERROR", "외부 API 연결에 실패했거나 응답이 유효하지 않습니다."),
+    GPT_BAD_RESPONSE(HttpStatus.BAD_GATEWAY, "GPT_BAD_RESPONSE", "모델 응답 형식이 올바르지 않습니다."),
+    GPT_PROVIDER_ERROR(HttpStatus.BAD_GATEWAY, "GPT_PROVIDER_ERROR", "모델 응답 생성 중 오류가 발생했습니다."),
+
 
     // 메뉴 관련
+    MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "MENU_NOT_FOUND", "메뉴 정보를 찾을 수 없습니다."),
+    ALLERGY_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, "ALLERGY_NOT_SUPPORTED", "허용 목록에 없는 알레르기 항목입니다."),
 
     // 가게 관련
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE_NOT_FOUND", "해당 가게를 찾을 수 없습니다."),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,6 @@ cloud.aws.credentials.access-key=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secret-key=${AWS_SECRET_KEY}
 cloud.aws.s3.bucket=${AWS_BUCKET}
 cloud.aws.region.static=${AWS_REGION}
+
+openai.api.key=${OPENAI_API_KEY}
+openai.model=gpt-4o-mini


### PR DESCRIPTION
## 📌 관련 이슈
  closed #28 

## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
사용자 가게의 모든 메뉴에 대해 알레르기 성분을 추출하는 기능입니다.
- 이 PR은 추출만 포함하며, 사용자가 인라인을 수정한 후 저장하는 기능은 다음 PR에서 다룰 예정입니다.
- 메뉴명 전처리 + 휴리스틱 규칙 + GPT 결과를 결합하여 정확도를 높였습니다.
- 동작 흐름: 
JWT로 내 가게 ID 추출 -> 가게의 모든 메뉴명에 대해 전처리 -> 휴리스틱 태그 도출 + 태그 알레르기 규칙 매핑으로 1차 알레르기 후보 산출 -> 메뉴명과 태그 힌트를 포함해 GPT에 요청(온도 0)-> GPT 응답에서 허용 목록 화이트리스트로 사후 검증하여 목록 밖의 값은 제거 -> 최종 알레르기는 휴리스틱 결과와 GPT 결과의 합집합으로 결정(중복은 제거)

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
<img width="1221" height="1475" alt="스크린샷 2025-08-14 232612" src="https://github.com/user-attachments/assets/3925e086-15b4-49b9-8575-ec365f4a49e2" />


## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
향후 정확도 개선 계획
- 휴리스틱 사전 강화: 키워드/동의어 보강
- few-shot 샘플 추가: 시장 실메뉴 2~30개 사례 추가
- 가게 카테고리를 GPT 힌트로 함께 전달 