### PR TITLE
[Feat] OCR 메뉴 추출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ dependencies {
 
 	// AWS
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
+
+	// CLOVA OCR
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ondongnae/backend/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/example/ondongnae/backend/global/config/security/SecurityConfig.java
@@ -52,8 +52,7 @@ public class SecurityConfig {
     @Bean
     public static CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of("http://localhost:3000"));
-
+        config.setAllowedOrigins(List.of("http://localhost:5173"));
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         config.setAllowCredentials(true);
         config.setAllowedHeaders(List.of("*"));

--- a/src/main/java/com/example/ondongnae/backend/global/response/ApiResponse.java
+++ b/src/main/java/com/example/ondongnae/backend/global/response/ApiResponse.java
@@ -1,11 +1,9 @@
 package com.example.ondongnae.backend.global.response;
 
-import com.amazonaws.Response;
 import com.example.ondongnae.backend.global.exception.ErrorCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatus;
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/example/ondongnae/backend/menu/controller/MenuController.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/controller/MenuController.java
@@ -2,12 +2,15 @@ package com.example.ondongnae.backend.menu.controller;
 
 import com.example.ondongnae.backend.global.response.ApiResponse;
 import com.example.ondongnae.backend.menu.dto.*;
+import com.example.ondongnae.backend.menu.service.MenuExtractionService;
 import com.example.ondongnae.backend.menu.service.MenuService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -16,11 +19,12 @@ import java.util.List;
 @RequestMapping("/me/menus")
 public class MenuController {
     private final MenuService menuService;
+    private final MenuExtractionService menuExtractionService;
 
-    // 수기 메뉴 등록
-    @PostMapping("/manual")
+    // 메뉴 저장 (수기/OCR 공통)
+    @PostMapping("/save")
     public ResponseEntity<ApiResponse<ManualMenuCreateResponse>> createManualMenu(
-            @RequestBody ManualMenuCreateRequest request
+            @Valid @RequestBody ManualMenuCreateRequest request
     ) {
         var response = menuService.createManual(request);
         return ResponseEntity.status(HttpStatus.CREATED)
@@ -41,6 +45,13 @@ public class MenuController {
     ) {
         MenuUpdateResponse data = menuService.replaceAll(request);
         return ResponseEntity.ok(ApiResponse.ok("메뉴 수정 완료", data));
+    }
+
+    // OCR 메뉴 추출
+    @PostMapping(value = "/allergens/extract", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<ApiResponse<OcrExtractResponse>> extract(@RequestPart("image") MultipartFile image) {
+        var res = menuExtractionService.extract(image);
+        return ResponseEntity.ok(ApiResponse.ok("메뉴 추출 성공", res));
     }
 
 }

--- a/src/main/java/com/example/ondongnae/backend/menu/dto/OcrExtractItemDto.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/dto/OcrExtractItemDto.java
@@ -1,0 +1,3 @@
+package com.example.ondongnae.backend.menu.dto;
+
+public record OcrExtractItemDto(String name, Integer priceKrw) {}

--- a/src/main/java/com/example/ondongnae/backend/menu/dto/OcrExtractResponse.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/dto/OcrExtractResponse.java
@@ -1,0 +1,5 @@
+package com.example.ondongnae.backend.menu.dto;
+
+import java.util.List;
+
+public record OcrExtractResponse(Long storeId, List<OcrExtractItemDto> items) {}

--- a/src/main/java/com/example/ondongnae/backend/menu/ocr/ClovaOcrClient.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/ocr/ClovaOcrClient.java
@@ -1,0 +1,144 @@
+package com.example.ondongnae.backend.menu.ocr;
+
+import com.example.ondongnae.backend.global.exception.BaseException;
+import com.example.ondongnae.backend.global.exception.ErrorCode;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.MediaType;
+import org.springframework.http.client.MultipartBodyBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+import org.springframework.web.reactive.function.BodyInserters;
+
+import java.io.IOException;
+import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+// CLOVA OCR API 호출 WebClient
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ClovaOcrClient {
+
+    private static final Set<String> ALLOWED = Set.of("jpg", "jpeg", "png", "pdf");
+
+    private final WebClient clovaOcrWebClient;
+    private final ClovaOcrProperties props;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    // CLOVA OCR 호출 -> 응답 본문을 모델로 반환
+    public ClovaOcrResponse callOcr(MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE, "이미지 파일이 비어 있습니다.");
+        }
+
+        String ext = getExtLower(image.getOriginalFilename());
+        if (!ALLOWED.contains(ext)) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE,
+                    "지원하지 않는 이미지 형식입니다. (허용: jpg, jpeg, png, pdf)");
+        }
+
+        // 1. message JSON 생성
+        String messageJson = buildMessageJson(ext);
+
+        // ★ 디버깅용(임시): URL/버전/확장자만 찍기. secret은 찍지 않음!
+        log.info("[CLOVA] url={}, version={}, ext={}, hasSecret={}",
+                props.invokeUrl(), props.version(), ext, props.secretKey()!=null);
+
+        // 2. multipart/form-data 바디 구성
+        MultipartBodyBuilder mb = new MultipartBodyBuilder();
+        mb.part("message", messageJson).contentType(MediaType.APPLICATION_JSON);
+        mb.part("file", toByteArrayResource(image))
+                .filename(Optional.ofNullable(image.getOriginalFilename()).orElse("menu.jpg"))
+                .contentType(mediaTypeFor(ext)); // 실제 타입 지정
+
+        // 3. WebClient 호출
+        try {
+            return clovaOcrWebClient.post()
+                    .header("X-OCR-SECRET", props.secretKey())
+                    .contentType(MediaType.MULTIPART_FORM_DATA)
+                    .accept(MediaType.APPLICATION_JSON)
+                    .body(BodyInserters.fromMultipartData(mb.build()))
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, resp ->
+                            resp.bodyToMono(String.class)
+                                    .defaultIfEmpty("")
+                                    .map(body -> {
+                                        // ★ 에러 메시지 더 명확히
+                                        String msg = "CLOVA 호출 실패: " + resp.statusCode() + " " + body;
+                                        log.warn("[CLOVA][HTTP_ERROR] {}", msg);
+                                        return new BaseException(ErrorCode.EXTERNAL_API_ERROR, msg);
+                                    }))
+                    .bodyToMono(ClovaOcrResponse.class)
+                    .block(); // 동기 처리
+        } catch (WebClientResponseException e) {
+            // CLOVA에서 4xx/5xx와 함께 보낸 바디를 포함해서 래핑
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR,
+                    "CLOVA 응답 오류: " + e.getResponseBodyAsString());
+        } catch (Exception e) {
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR,
+                    "CLOVA 호출 중 예외: " + e.getMessage());
+        }
+    }
+
+    // CLOVA가 요구하는 message JSON(버전/요청ID/타임스탬프/이미지 포맷)을 생성
+    private String buildMessageJson(String extLower) {
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("version", props.version());                       // 예: "V2"
+        root.put("requestId", UUID.randomUUID().toString());
+        root.put("timestamp", System.currentTimeMillis());
+
+        ArrayNode images = root.putArray("images");
+        ObjectNode img = images.addObject();
+        img.put("format", extLower);                                 // 소문자 확장자
+        img.put("name", "menu");
+
+        try {
+            return objectMapper.writeValueAsString(root);
+        } catch (JsonProcessingException e) {
+            throw new BaseException(ErrorCode.INTERNAL_SERVER_ERROR, "CLOVA 요청 JSON 생성 실패");
+        }
+    }
+
+    private static ByteArrayResource toByteArrayResource(MultipartFile file) {
+        try {
+            byte[] bytes = file.getBytes();
+            return new ByteArrayResource(bytes) {
+                @Override public String getFilename() {
+                    return Optional.ofNullable(file.getOriginalFilename()).orElse("menu.jpg");
+                }
+            };
+        } catch (IOException e) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE, "이미지 읽기 실패");
+        }
+    }
+
+    // 파일 확장자를 소문자로 반환
+    private static String getExtLower(String filename) {
+        if (filename == null) return "jpg";
+        int idx = filename.lastIndexOf('.');
+        String raw = (idx > -1 && idx < filename.length() - 1) ? filename.substring(idx + 1) : "jpg";
+        return raw.toLowerCase(Locale.ROOT);
+    }
+
+    // 확장자에 대응하는 Content-Type
+    private static MediaType mediaTypeFor(String ext) {
+        return switch (ext) {
+            case "jpg", "jpeg" -> MediaType.IMAGE_JPEG;
+            case "png"         -> MediaType.IMAGE_PNG;
+            case "pdf"         -> MediaType.APPLICATION_PDF;
+            default            -> MediaType.APPLICATION_OCTET_STREAM;
+        };
+    }
+
+}

--- a/src/main/java/com/example/ondongnae/backend/menu/ocr/ClovaOcrProperties.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/ocr/ClovaOcrProperties.java
@@ -1,0 +1,13 @@
+package com.example.ondongnae.backend.menu.ocr;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+// application.properties의 clova.ocr 값을 바인딩
+@ConfigurationProperties(prefix = "clova.ocr")
+public record ClovaOcrProperties(
+        String invokeUrl,
+        String secretKey,
+        String version,
+        Integer connectTimeoutMs,
+        Integer readTimeoutMs
+) {}

--- a/src/main/java/com/example/ondongnae/backend/menu/ocr/ClovaOcrResponse.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/ocr/ClovaOcrResponse.java
@@ -1,0 +1,31 @@
+package com.example.ondongnae.backend.menu.ocr;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+// CLOVA OCR 응답 JSON을 역직렬화
+@Getter
+@NoArgsConstructor
+public class ClovaOcrResponse {
+    private String version;
+    private String requestId;
+    private long timestamp;
+    private List<ImageResult> images;
+
+    @Getter @NoArgsConstructor
+    public static class ImageResult {
+        private String uid;
+        private String name;
+        private String inferResult;       // SUCCESS / FAILURE
+        private String message;
+        private List<Field> fields;
+    }
+    @Getter @NoArgsConstructor
+    public static class Field {
+        private String inferText;         // 인식 텍스트
+        private Double inferConfidence;   // 신뢰도(옵션)
+        private Boolean lineBreak;        // 줄바꿈 여부(옵션)
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/menu/ocr/OcrClientConfig.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/ocr/OcrClientConfig.java
@@ -1,0 +1,31 @@
+package com.example.ondongnae.backend.menu.ocr;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.netty.http.client.HttpClient;
+import io.netty.channel.ChannelOption;
+
+import java.time.Duration;
+
+// CLOVA OCR 호출용 WebClient
+@Configuration
+@EnableConfigurationProperties(ClovaOcrProperties.class)
+public class OcrClientConfig {
+
+    @Bean
+    public WebClient clovaOcrWebClient(ClovaOcrProperties props) {
+        // Netty 클라이언트에 커넥션/응답 타임아웃 설정
+        HttpClient httpClient = HttpClient.create()
+                .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, props.connectTimeoutMs())
+                .responseTimeout(Duration.ofMillis(props.readTimeoutMs()));
+
+        // WebClient 빌더에 Netty 커넥터 적용
+        return WebClient.builder()
+                .baseUrl(props.invokeUrl())
+                .clientConnector(new ReactorClientHttpConnector(httpClient))
+                .build();
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/menu/service/MenuExtractionService.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/service/MenuExtractionService.java
@@ -1,0 +1,67 @@
+package com.example.ondongnae.backend.menu.service;
+
+import com.example.ondongnae.backend.global.exception.BaseException;
+import com.example.ondongnae.backend.global.exception.ErrorCode;
+import com.example.ondongnae.backend.member.service.AuthService;
+import com.example.ondongnae.backend.menu.dto.OcrExtractResponse;
+import com.example.ondongnae.backend.menu.ocr.ClovaOcrClient;
+import com.example.ondongnae.backend.menu.ocr.ClovaOcrResponse;
+import com.example.ondongnae.backend.store.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MenuExtractionService {
+
+    private final AuthService authService;
+    private final StoreRepository storeRepository;
+    private final ClovaOcrClient clovaOcrClient;
+    private final MenuTextParser parser;
+
+    public OcrExtractResponse extract(MultipartFile image) {
+        // 토큰 -> 내 가게 ID 확인
+        Long storeId = authService.getMyStoreId();
+
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new BaseException(ErrorCode.STORE_NOT_FOUND));
+
+        if (image == null || image.isEmpty()) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE, "이미지 파일이 비었습니다.");
+        }
+
+        var resp = clovaOcrClient.callOcr(image);
+        var text = joinInferTexts(resp);
+
+        var items = parser.parse(text);
+        if (items.isEmpty()) {
+            throw new BaseException(ErrorCode.INVALID_INPUT_VALUE, "메뉴 텍스트를 찾지 못했습니다.");
+        }
+        return new OcrExtractResponse(storeId, items);
+    }
+
+    // fields[*].inferText를 줄바꿈 기준으로 조합
+    private String joinInferTexts(ClovaOcrResponse resp) {
+        if (resp.getImages() == null || resp.getImages().isEmpty()) {
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "CLOVA 응답에 images가 없습니다.");
+        }
+        var img = resp.getImages().get(0);
+        if (!"SUCCESS".equalsIgnoreCase(img.getInferResult())) {
+            throw new BaseException(ErrorCode.EXTERNAL_API_ERROR, "CLOVA 인식 실패: " + img.getMessage());
+        }
+        if (img.getFields() == null || img.getFields().isEmpty()) return "";
+
+        StringBuilder sb = new StringBuilder();
+        for (var f : img.getFields()) {
+            if (f.getInferText() == null) continue;
+            sb.append(f.getInferText());
+            // lineBreak가 true면 줄바꿈, 아니면 공백
+            if (Boolean.TRUE.equals(f.getLineBreak())) sb.append('\n');
+            else sb.append(' ');
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/example/ondongnae/backend/menu/service/MenuService.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/service/MenuService.java
@@ -27,7 +27,7 @@ public class MenuService {
     private final MenuAllergyRepository menuAllergyRepository;
     private final TranslateService translateService;
 
-    // 수기 메뉴 등록
+    // 메뉴 저장 (수기/OCR 공통)
     @Transactional
     public ManualMenuCreateResponse createManual(ManualMenuCreateRequest request) {
         // 1. 토큰 -> 내 가게 ID 추출

--- a/src/main/java/com/example/ondongnae/backend/menu/service/MenuTextParser.java
+++ b/src/main/java/com/example/ondongnae/backend/menu/service/MenuTextParser.java
@@ -1,0 +1,172 @@
+package com.example.ondongnae.backend.menu.service;
+
+import com.example.ondongnae.backend.menu.dto.OcrExtractItemDto;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * OCR 원문 텍스트를 한 줄씩 파싱해 (메뉴명, 가격) DTO로 생성
+ * 괄호/수량/옵션/이모지 등 잡값 제거
+ * 가격 패턴: 5,000원 / 7000 / 7000원 / 7,000 won / 7000 krw
+ * 가격 미검출은 null 허용(프론트 인라인 수정에서 입력)
+ */
+@Component
+public class MenuTextParser {
+
+    // 가격: 1~3자리 + (콤마 + 3자리)* 또는 단순 숫자, 뒤에 통화표기 옵션
+    // 예) 9,000 / 15000 / 3,000원 / 1000 KRW / 7,000 won
+    private static final Pattern PRICE = Pattern.compile(
+            "(\\d{1,3}(?:,\\d{3})+|\\d+)\\s*(?:원|₩|￦|krw|won)?",
+            Pattern.CASE_INSENSITIVE);
+    // 라인 끝이나 괄호/공백 사이에 오는 사이즈 토큰들
+    // (한글/한자 혼용, '대/중/소', '大/中/小', 그리고 흔한 오인식: C -> 중으로 매핑)
+    private static final Pattern SIZE_TOKEN = Pattern.compile("(?:\\(|\\s|^)(대|중|소|大|中|小|C)(?:\\)|\\s|$)");
+
+    public List<OcrExtractItemDto> parse(String raw) {
+        if (raw == null || raw.isBlank()) return List.of();
+
+        // 줄 단위 분리 (OCR lineBreak 기준으로 들어옴)
+        String[] lines = raw.replace('\u00A0', ' ').split("\\r?\\n");
+
+        List<OcrExtractItemDto> result = new ArrayList<>();
+        String pendingName = null;      // 가격 없는 이름을 임시 보관
+        String pendingSize = null;      // 라인에서 분리된 사이즈 토큰(중/대/小/中/大/C)
+
+        for (String originalLine : lines) {
+            String line = normalize(originalLine);
+            if (line.isBlank()) continue;
+
+            // (1) 사이즈 토큰 분리(있으면 보관)
+            //  예) "소머리수육 中" -> name="소머리수육", size="중"
+            String size = extractSize(line);
+            if (size != null) {
+                pendingSize = size;
+                line = removeSize(line); // 사이즈 텍스트 제거
+                line = line.trim();
+            }
+
+            // (2) 가격 매칭 시도
+            Matcher m = PRICE.matcher(line);
+            if (m.find()) {
+                // 가격 추출 -> 쉼표 제거
+                String num = m.group(1).replace(",", "");
+                Integer price = safeParseInt(num);
+
+                // 가격 앞부분을 이름으로 (뒤의 꼬리 텍스트는 버림)
+                String name = line.substring(0, m.start()).trim();
+
+                // 이름이 비어있으면, 이전 줄에 있던 이름을 사용
+                if (name.isBlank() && pendingName != null) {
+                    name = pendingName;
+                    pendingName = null; // 소모
+                }
+
+                // 사이즈 표기 보존 (예: "소머리수육 (중)")
+                if (pendingSize != null) {
+                    name = appendSize(name, pendingSize);
+                    pendingSize = null;
+                }
+
+                // 이름 최소 길이 필터 (오인식 한 글자 제거)
+                if (isNoise(name)) continue;
+
+                if (!name.isBlank()) {
+                    result.add(new OcrExtractItemDto(name, price));
+                }
+                continue; // 다음 라인
+            }
+
+            // (3) 이 라인에는 가격이 없고, 유의미한 이름인 경우 → 다음 줄 가격과 결합하기 위해 보관
+            if (!isNoise(line)) {
+                // 만약 이전에 보관된 이름이 남아있다면 먼저 추가(가격 null 허용)
+                // -> "소주" 같은 라인들이 가격이 다른 줄에 없어도 남도록
+                if (pendingName != null && !pendingName.equals(line)) {
+                    // 이전 보관값을 가격 null로 기록
+                    result.add(new OcrExtractItemDto(
+                            pendingSize != null ? appendSize(pendingName, pendingSize) : pendingName,
+                            null));
+                    pendingSize = null;
+                }
+                pendingName = line;
+            }
+        }
+
+        // 끝났는데 pendingName 남아있으면 기록(가격 null)
+        if (pendingName != null && !isNoise(pendingName)) {
+            result.add(new OcrExtractItemDto(
+                    pendingSize != null ? appendSize(pendingName, pendingSize) : pendingName,
+                    null));
+        }
+
+        return result;
+    }
+
+    /** 공백/기호 정리. 콤마(,)는 여기서 건드리지 않는다! (가격 정규식에서 다룸) */
+    private String normalize(String s) {
+        // 이모지/기호류 제거 (필요시 축소 가능)
+        String noEmoji = s.replaceAll("[\\p{So}\\p{Cn}]", " ");
+        // 괄호 일단 보존(사이즈 토큰 추출에 쓰일 수 있음)
+        String trimmed = noEmoji
+                .replaceAll("[\\t\\r]", " ")
+                .replaceAll("\\s{2,}", " ")
+                .trim();
+        return trimmed;
+    }
+
+    /** 한 글자 잡값/노이즈 라인 필터 */
+    private boolean isNoise(String name) {
+        if (name == null) return true;
+        String n = name.trim();
+        if (n.isEmpty()) return true;
+        // 'C' 같은 한 글자 노이즈 제거
+        if (n.length() == 1 && !Character.isDigit(n.charAt(0))) return true;
+        // 불필요한 접두/접미만 남은 경우
+        return false;
+    }
+
+    /** "중/대/小/中/大/C" 같은 사이즈 토큰을 (가능하면) 추출 */
+    private String extractSize(String line) {
+        Matcher m = SIZE_TOKEN.matcher(line);
+        if (m.find()) {
+            String raw = m.group(1);
+            return normalizeSize(raw);
+        }
+        return null;
+    }
+
+    /** 라인에서 사이즈 토큰 제거 */
+    private String removeSize(String line) {
+        return SIZE_TOKEN.matcher(line).replaceAll(" ").replaceAll("\\s{2,}", " ");
+    }
+
+    /** 'C' 오인식 → '중'으로 보정, 한자 → 한글 */
+    private String normalizeSize(String s) {
+        switch (s) {
+            case "大": return "대";
+            case "中": return "중";
+            case "小": return "소";
+            case "C":  return "중"; // 흔한 오탐 보정
+            default:   return s;    // 대/중/소
+        }
+    }
+
+    /** 이름 뒤에 사이즈를 괄호로 표기 */
+    private String appendSize(String name, String size) {
+        name = (name == null ? "" : name.trim());
+        if (name.isEmpty()) return name;
+        return name + " (" + size + ")";
+    }
+
+    private Integer safeParseInt(String n) {
+        try {
+            return Integer.parseInt(n);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}
+

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -19,3 +19,11 @@ cloud.aws.region.static=${AWS_REGION}
 
 openai.api.key=${OPENAI_API_KEY}
 openai.model=gpt-4o-mini
+
+clova.ocr.invoke-url=${CLOVA_OCR_INVOKE_URL}
+clova.ocr.secret-key=${CLOVA_OCR_SECRET}
+clova.ocr.version=V2
+clova.ocr.connect-timeout-ms=5000
+clova.ocr.read-timeout-ms=15000
+spring.servlet.multipart.max-file-size=10MB
+spring.servlet.multipart.max-request-size=10MB


### PR DESCRIPTION
## 📌 관련 이슈
  closed #38 


## ✅ 작업 내용
<!-- 작업에 대한 설명을 적어주세요 -->
CLOVA OCR 연동으로 메뉴판 이미지에서 메뉴명/가격을 추출하는 기능입니다.
- OcrClientConfig: CLOVA 호출용 WebClient 빈생성
- ClovaOcrProperties: invoke-url, secret-key 등 바인딩
- ClovaOcrClient: CLOVA OCR 호출 -> 응답 본문을 모델로 반환
- ClovaOcrResponse: CLOVA 응답 DTO
- MenuTextParser: OCR 텍스트를 메뉴명, 가격으로 변환하는 규칙 파서
  - 콤마는 매칭 후 제거 (9,000 -> 9000)
  - 전 줄 이름 + 다음 줄 가격 결합(칼럼 OCR 대응)
  - 사이즈 토큰(中/大/소) 보존(ex. 소머리수육 (중))
  - 1글자 노이즈 제거
## 📸 스크린샷(선택)
<!-- 스크린샷이 필요하다면 스크린샷을 첨부해주세요 -->
<img width="894" height="471" alt="스크린샷 2025-08-17 213449" src="https://github.com/user-attachments/assets/a824c842-ec0b-4f3b-87ce-64259aa669d3" />
<img width="1244" height="1472" alt="스크린샷 2025-08-18 000310" src="https://github.com/user-attachments/assets/d63cad26-67c1-4018-ad46-aee676cf83cb" />





## 💬 리뷰 참고 사항
<!-- 코드 리뷰 시 유의해야 할 점을 적어주세요 -->
추후 개선 사항
- 좌표 기반 파싱으로 전환
  - 가운데, 오른쪽 칼럼 누락 (라면~컵떡볶이만 추출됨)
- 수량(개/잔/컵 등) 숫자와 가격 숫자 구분 
  - 라인 내에 수량이 있으면 이름에 흡수 ex: "어묵 3개"